### PR TITLE
Action parameters can now include variable expressions

### DIFF
--- a/cactus_test_definitions/test_procedures.py
+++ b/cactus_test_definitions/test_procedures.py
@@ -6,6 +6,10 @@ from typing import Any, Iterable
 
 import yaml
 import yaml_include
+from cactus_test_definitions.variable_expressions import (
+    parse_variable_expression_body,
+    try_extract_variable_expression,
+)
 from dataclass_wizard import YAMLWizard
 
 
@@ -29,6 +33,14 @@ class Event:
 class Action:
     type: str
     parameters: dict[str, Any]
+
+    def __post_init__(self):
+        """Some parameter values might contain variable expressions (eg: a string "$now") that needs to be replaced
+        with an parsed Expression object instead."""
+        for k, v in self.parameters.items():
+            variable_expr = try_extract_variable_expression(v)
+            if variable_expr:
+                self.parameters[k] = parse_variable_expression_body(variable_expr)
 
 
 @dataclass
@@ -60,6 +72,7 @@ class TestProcedures(YAMLWizard):
     By sub-classing the YAMLWizard mixin, we get access to the class method `from_yaml`
     which we can use to create an instances of `TestProcedures`.
     """
+
     __test__ = False  # Prevent pytest from picking up this class
 
     description: str

--- a/cactus_test_definitions/variable_expressions.py
+++ b/cactus_test_definitions/variable_expressions.py
@@ -1,0 +1,238 @@
+from dataclasses import dataclass
+from datetime import timedelta
+from enum import IntEnum, auto
+from io import StringIO
+from re import match, search
+from tokenize import NAME, NUMBER, OP, STRING, TokenError, TokenInfo, generate_tokens
+from typing import Any
+
+ConstantType = timedelta | int | float
+
+
+class NamedVariableType(IntEnum):
+    # MUST resolve to a tz aware representation of the current datetime
+    # Referenced in a test definition as $(now)
+    NOW = auto()
+
+    # MUST resolve to the "DERSetting.setMaxW" of the current EndDevice under test. Value in Watts
+    # Referenced in a test definition as $(setMaxW)
+    DERSETTING_SET_MAX_W = auto()
+
+
+class OperationType(IntEnum):
+    ADD = auto()
+    SUBTRACT = auto()
+    MULTIPLY = auto()
+    DIVIDE = auto()
+
+
+OPERATION_MAPPINGS = {
+    "+": OperationType.ADD,
+    "-": OperationType.SUBTRACT,
+    "*": OperationType.MULTIPLY,
+    "/": OperationType.DIVIDE,
+}
+
+
+@dataclass
+class Constant:
+    """Represents a constant value that doesn't require any test execution time resolution"""
+
+    value: ConstantType  # The parsed value
+
+
+@dataclass
+class NamedVariable:
+    """A "NamedVariable" is value that can only be resolved at point during a test procedure execution (eg: as a
+    listener action is being applied). There are a fixed set of known variable types defined by NamedVariableType.
+
+    Failures during resolving a variable (eg database doesn't have the data) MUST raise an exception
+    """
+
+    variable: NamedVariableType
+
+
+@dataclass
+class Expression:
+    """An expression is a simple combination of two values that combine to make a single constant value. The operands
+    can be constants or NamedVariables."""
+
+    operation: OperationType
+    lhs_operand: NamedVariable | Constant  # left hand side operand
+    rhs_operand: NamedVariable | Constant  # right hand side operand
+
+
+class UnresolvableVariableError(Exception):
+    """Raised whenever a NamedVariable cannot be resolved at test execution time (eg: database doesn't have the
+    requisite information)"""
+
+    pass
+
+
+class UnparseableVariableExpressionError(Exception):
+    """Raised whenever a raw string cannot parse to a NamedVariable/Expression"""
+
+    pass
+
+
+def parse_time_delta(var_body: str) -> timedelta:
+    """Parses a string like '5 minutes' into a representative timedelta"""
+
+    m = match(r"(['\"])([0-9\-\.]*)\s*([^']*)(['\"])", var_body)
+    if m is None:
+        raise UnparseableVariableExpressionError(f"{var_body} can't be parsed into a timedelta")
+
+    open_quote = m.group(1)
+    number_string = m.group(2)
+    time_unit_string = m.group(3).lower()
+    close_quote = m.group(4)
+
+    if open_quote != close_quote:
+        raise UnparseableVariableExpressionError(f"{var_body} can't be parsed into a timedelta. Mismatching quotes")
+
+    try:
+        number = float(number_string)
+    except ValueError:
+        raise UnparseableVariableExpressionError(
+            f"{var_body} can't be parsed into a timedelta. Bad number {number_string}"
+        )
+
+    if time_unit_string in {"day", "days"}:
+        return timedelta(days=number)
+    elif time_unit_string in {"hour", "hours", "hrs", "hr"}:
+        return timedelta(hours=number)
+    elif time_unit_string in {"minute", "minutes", "min", "mins"}:
+        return timedelta(minutes=number)
+    elif time_unit_string in {"second", "seconds", "sec", "secs"}:
+        return timedelta(seconds=number)
+    else:
+        raise UnparseableVariableExpressionError(
+            f"{var_body} can't be parsed into a timedelta. Unknown unit {time_unit_string}"
+        )
+
+
+def parse_unary_expression(token: TokenInfo) -> Constant | NamedVariable:
+    """Parses a unary expression from a variable body"""
+
+    if token.type == NAME:
+        match token.string.lower():
+            case "now":
+                return NamedVariable(NamedVariableType.NOW)
+            case "setmaxw":
+                return NamedVariable(NamedVariableType.DERSETTING_SET_MAX_W)
+
+        raise UnparseableVariableExpressionError(f"'{token.string}' isn't recognized as a named variable")
+
+    try:
+        if token.type == NUMBER:
+            if "." in token.string:
+                return Constant(float(token.string))
+            else:
+                return Constant(int(token.string))
+    except ValueError:
+        raise UnparseableVariableExpressionError(f"'{token.string}' can't be converted to a number")
+
+    if token.type == STRING:
+        return Constant(parse_time_delta(token.string))
+
+    raise UnparseableVariableExpressionError(f"Unable to parse token {token}")
+
+
+def parse_binary_expression(lhs_token: TokenInfo, operation: TokenInfo, rhs_token: TokenInfo) -> Expression:
+
+    if operation.type != OP:
+        raise UnparseableVariableExpressionError(f"Expected an operation (eg + - / *) but found {operation}")
+
+    operation_type = OPERATION_MAPPINGS.get(operation.string, None)
+    if operation_type is None:
+        raise UnparseableVariableExpressionError(f"Unable to parse operator {operation.string} into a OperationType")
+
+    lhs = parse_unary_expression(lhs_token)
+    rhs = parse_unary_expression(rhs_token)
+
+    return Expression(operation=operation_type, lhs_operand=lhs, rhs_operand=rhs)
+
+
+def parse_variable_expression_body(var_body: str) -> NamedVariable | Expression | Constant:
+    """Given a variable definition: $(now - '5 seconds') - this function should be passed contents of that variable
+    definition (the string within the parentheses) eg: "now - '5 seconds'
+
+    returns a parsed NamedVariable or Expression or raises UnparseableVariableExpressionError otherwise
+
+    Cheat sheet of common variable patterns:
+
+    $(now) - Will return a tz aware datetime corresponding to the current moment in time
+    $(now - '5 minute') - Same as above, but offset 5 minutes in the past
+    $(0.5 * DERSetting.setMaxW) - 50% of the currently configured setMaxW for the current EndDevice
+    """
+    if not var_body:
+        raise UnparseableVariableExpressionError("var_body is empty/None")
+
+    # Use the python parser to generate a simplified set of tokens representing the variable definition
+    try:
+
+        var_tokens = [t for t in generate_tokens(StringIO(var_body).readline) if t.type in {NUMBER, OP, STRING, NAME}]
+    except TokenError as exc:
+        raise UnparseableVariableExpressionError(f"Error tokenizing '{var_body}': {exc}")
+
+    if len(var_tokens) == 1:
+        return parse_unary_expression(var_tokens[0])
+    elif len(var_tokens) == 3:
+        return parse_binary_expression(var_tokens[0], var_tokens[1], var_tokens[2])
+    else:
+        raise UnparseableVariableExpressionError(f"Unable to parse {var_body} into a simple binary/unary expression")
+
+
+def try_extract_variable_expression(body: Any) -> str | None:
+    """Checks to see if a variable body (of any type) can be parsed by parse_variable_expression_body. If it can,
+    it will be returned as a string. Otherwise None will be returned
+
+    Can raise ValueError if body is a string appearing to contain a variable expression that is malformed (eg
+    mismatching parentheses)"""
+    if not isinstance(body, str):
+        return None
+
+    begin_variable_defn = body.find("$")
+    if begin_variable_defn < 0:
+        return None
+
+    # The $ variable definition can be escaped with \$ so ensure it is checked
+    if begin_variable_defn > 0 and (body[begin_variable_defn - 1] == "\\"):
+        return None
+
+    # At this point we are definitely parsing a variable expression. Failures here will raise ValueError
+    if begin_variable_defn >= (len(body) - 1):
+        raise ValueError(f"'{body}' appears to be a malformed variable definition. Try escaping $ like '\\$'")
+
+    start_expr_body: int
+    end_expr_body: int
+    end_variable_defn: int  # First character after the end of the full variable definition
+    if body[begin_variable_defn + 1] == "(":
+        start_expr_body = begin_variable_defn + 2
+        end_expr_body = body.index(")", start_expr_body)
+        end_variable_defn = end_expr_body + 2
+    else:
+        start_expr_body = begin_variable_defn + 1
+
+        remainder = body[start_expr_body:]
+        match_variable = match(r"[_a-zA-Z0-9]*", remainder)
+        if match_variable is None:
+            raise ValueError(f"'{body}' appears to be a malformed variable definition")
+        else:
+            end_expr_body = start_expr_body + match_variable.end()
+            end_variable_defn = end_expr_body + 1
+
+    if start_expr_body == end_expr_body:
+        raise ValueError(f"'{body}' appears to be a malformed variable definition.")
+    variable_expression = body[start_expr_body:end_expr_body]
+
+    # One last validation to look for leading/trailing text which would indicate
+    leading_text = search(r"[^\s]", body[0:begin_variable_defn])
+    if leading_text is not None:
+        raise ValueError("Variable expressions must ONLY be a single variable with no other text")
+
+    trailing_text = search(r"[^\s]", body[end_variable_defn:])
+    if trailing_text is not None:
+        raise ValueError("Variable expressions must ONLY be a single variable with no other text")
+
+    return variable_expression

--- a/tests/data/config_action_parameters.yaml
+++ b/tests/data/config_action_parameters.yaml
@@ -1,0 +1,47 @@
+---
+Description: CSIP-AUS Client Test Procedures
+Version: 0.1
+TestProcedures:
+  CUSTOM-01:
+    Description: Tests Action Parameters
+    Category: Test
+    Classes:
+      - A
+    Steps:
+      Step-1:
+        listener-enabled: true
+        event:
+          type: request-received
+          parameters:
+            endpoint: /dcap
+        actions:
+          - type: test-action-1
+            parameters:
+              param_list_str:
+                - List Item 1
+                - List Item 2
+                - List Item 3
+              param_list_int:
+                - 11
+                - 22
+                - 33
+              param_list_mixed:
+                - 11
+                - 2.2
+                - 'List Item 3'
+                - 2020-01-02 03:04:05Z
+              param_dict_str:
+                key1: value1
+                key2: value2
+              param_dict_int:
+                key11: 11
+                key22: 22
+              param_int: 11
+              param_str: Value 11
+              param_datetime_utc: 2025-01-02 03:04:05Z
+              param_datetime_naive: 2025-01-02 03:04:05
+              param_with_variable_date: $(now)
+              param_with_variable_db_lookup:   $(setMaxW)  
+              param_with_variable_relative_db_lookup: $(0.25 * setMaxW)
+              param_with_variable_relative_date: $(now - '5 minutes')
+          

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,8 +1,15 @@
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
-
 from cactus_test_definitions import TestProcedureConfig, TestProcedureDefinitionError
+from cactus_test_definitions.variable_expressions import (
+    Constant,
+    Expression,
+    NamedVariable,
+    NamedVariableType,
+    OperationType,
+)
 
 
 def test_from_yamlfile():
@@ -24,3 +31,36 @@ def test_TestProcedures_validate_raises_exception(filename: str):
 
     with pytest.raises(TestProcedureDefinitionError):
         _ = TestProcedureConfig.from_yamlfile(path=Path(filename))
+
+
+def test_TestProcedures_action_parameter_types():
+    """Tests that lists/dicts/constants/datetimes can all be encoded/decoded via the yaml action definition"""
+    cfg = TestProcedureConfig.from_yamlfile(path=Path("tests/data/config_action_parameters.yaml"))
+    test_proc = cfg.test_procedures["CUSTOM-01"]
+    step = test_proc.steps["Step-1"]
+    action = step.actions[0]
+
+    assert action.parameters == {
+        "param_list_str": ["List Item 1", "List Item 2", "List Item 3"],
+        "param_list_int": [11, 22, 33],
+        "param_list_mixed": [
+            11,
+            2.2,
+            "List Item 3",
+            datetime(2020, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        ],
+        "param_dict_str": {"key1": "value1", "key2": "value2"},
+        "param_dict_int": {"key11": 11, "key22": 22},
+        "param_int": 11,
+        "param_str": "Value 11",
+        "param_datetime_utc": datetime(2025, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        "param_datetime_naive": datetime(2025, 1, 2, 3, 4, 5, tzinfo=None),
+        "param_with_variable_date": NamedVariable(NamedVariableType.NOW),
+        "param_with_variable_db_lookup": NamedVariable(NamedVariableType.DERSETTING_SET_MAX_W),
+        "param_with_variable_relative_db_lookup": Expression(
+            OperationType.MULTIPLY, Constant(0.25), NamedVariable(NamedVariableType.DERSETTING_SET_MAX_W)
+        ),
+        "param_with_variable_relative_date": Expression(
+            OperationType.SUBTRACT, NamedVariable(NamedVariableType.NOW), Constant(timedelta(minutes=5))
+        ),
+    }

--- a/tests/unit/test_variable_expressions.py
+++ b/tests/unit/test_variable_expressions.py
@@ -1,0 +1,187 @@
+from datetime import datetime, timedelta
+from typing import Any
+
+import pytest
+from cactus_test_definitions.variable_expressions import (
+    Constant,
+    Expression,
+    NamedVariable,
+    NamedVariableType,
+    OperationType,
+    UnparseableVariableExpressionError,
+    parse_time_delta,
+    parse_variable_expression_body,
+    try_extract_variable_expression,
+)
+
+
+@pytest.mark.parametrize(
+    "body, expected",
+    [
+        (None, None),
+        (123, None),
+        (12.3, None),
+        (["$no_list_inspection"], None),
+        ({"$no_dict_inspection": "$no_dict_inspection"}, None),
+        (datetime(2001, 2, 3), None),
+        ("", None),
+        ("  ", None),
+        ("$now", "now"),
+        ("  $now\n  ", "now"),
+        ("$(now)", "now"),
+        ("$(now - '5 minutes')", "now - '5 minutes'"),
+        ("$(  now - '5 minutes'  )", "  now - '5 minutes'  "),
+        ("\\$(now)", None),  # escaped
+        ("  \\$(now) ", None),  # escaped
+        ("  \\$now ", None),  # escaped
+        ("\\$now", None),  # escaped
+        ("$variable_with_556", "variable_with_556"),
+        ("$(variable_with_556)", "variable_with_556"),
+        ("$variable-556", ValueError),  # Don't allow "non variable" data to get omitted
+        ("$(variable-556)", "variable-556"),
+        ("$longer_variable no spaces", ValueError),
+        ("$(longer_variable but include everything)", "longer_variable but include everything"),
+        ("$(now", ValueError),  # Unclosed bracket
+        (" $(now  ", ValueError),  # Unclosed bracket
+        (" $(now foo", ValueError),  # Unclosed bracket
+        ("$ invalid_space", ValueError),
+        ("$-invalid_char", ValueError),
+        ("$", ValueError),  # No variable body included
+        ("$ ", ValueError),  # No variable body included
+        ("\\$", None),
+        ("$()", ValueError),  # No variable body included
+        ("\\$()", None),
+        (" \\$() ", None),
+        ("$(valid) no trailing data", ValueError),  # A string is either a variable or not. Can't substring variables
+        ("no leading data $(valid)", ValueError),  # A string is either a variable or not. Can't substring variables
+    ],
+)
+def test_try_extract_variable_expression(body: Any, expected: str | None | type[Exception]):
+    """Various test cases that try expose edge cases in try_extract_variable_expression"""
+    if isinstance(expected, type):
+        with pytest.raises(expected):
+            try_extract_variable_expression(body)
+    else:
+        actual = try_extract_variable_expression(body)
+        assert actual is None or isinstance(actual, str)
+        assert actual == expected, f"Input string: '{body}'"
+
+
+@pytest.mark.parametrize(
+    "unquoted_raw, expected",
+    [
+        ("", UnparseableVariableExpressionError),
+        ("5 mins", timedelta(minutes=5)),
+        ("-5 mins", timedelta(minutes=-5)),
+        ("5.23 mins", timedelta(minutes=5.23)),
+        ("-5.23 mins", timedelta(minutes=-5.23)),
+        ("-0.03 days", timedelta(days=-0.03)),
+        ("-0.03   days", timedelta(days=-0.03)),
+        ("-0.03days", timedelta(days=-0.03)),
+        ("4 minutes", timedelta(minutes=4)),
+        ("4 minute", timedelta(minutes=4)),
+        ("0 minute", timedelta(minutes=0)),
+        ("4 hours", timedelta(hours=4)),
+        ("4 hour", timedelta(hours=4)),
+        ("4 hrs", timedelta(hours=4)),
+        ("4 hr", timedelta(hours=4)),
+        ("4 days", timedelta(days=4)),
+        ("4 day", timedelta(days=4)),
+        ("4 seconds", timedelta(seconds=4)),
+        ("4 second", timedelta(seconds=4)),
+        ("4 secs", timedelta(seconds=4)),
+        ("4 sec", timedelta(seconds=4)),
+        ("4 foo", UnparseableVariableExpressionError),  # Unknown unit
+        ("4-.2 foo", UnparseableVariableExpressionError),  # Not a number
+        ("4.2.3 foo", UnparseableVariableExpressionError),  # Not a number
+    ],
+)
+def test_parse_time_delta(unquoted_raw: str, expected: timedelta | type[Exception]):
+    """Tests the various ways a time delta interval can be encoded (and the various ways it can fail)"""
+    VALID_QUOTE_CHARS = ["'", '"']
+
+    # Check weird edge cases from unquoted intervals or badly quoted intervals
+    with pytest.raises(UnparseableVariableExpressionError):
+        parse_time_delta(unquoted_raw)
+
+    for quote_char in ["'", '"']:
+        with pytest.raises(UnparseableVariableExpressionError):
+            parse_time_delta(quote_char + unquoted_raw)
+        with pytest.raises(UnparseableVariableExpressionError):
+            parse_time_delta(unquoted_raw + quote_char)
+
+    with pytest.raises(UnparseableVariableExpressionError):
+        parse_time_delta(VALID_QUOTE_CHARS[0] + quote_char + VALID_QUOTE_CHARS[1])
+    with pytest.raises(UnparseableVariableExpressionError):
+        parse_time_delta(VALID_QUOTE_CHARS[1] + quote_char + VALID_QUOTE_CHARS[0])
+
+    # Now do the actual test
+    if isinstance(expected, type):
+        for quote_char in VALID_QUOTE_CHARS:
+            with pytest.raises(expected):
+                parse_time_delta(quote_char + unquoted_raw + quote_char)
+    else:
+        for quote_char in VALID_QUOTE_CHARS:
+            actual = parse_time_delta(quote_char + unquoted_raw + quote_char)
+            assert isinstance(actual, timedelta)
+            assert actual == expected, f"Input string: {quote_char + unquoted_raw + quote_char}"
+
+
+@pytest.mark.parametrize(
+    "var_body, expected",
+    [
+        ("1.23", Constant(1.23)),
+        ("123", Constant(123)),
+        ("  123  ", Constant(123)),
+        ("'-4.56 hours'", Constant(timedelta(hours=-4.56))),
+        ('"0.12 days"', Constant(timedelta(days=0.12))),
+        (" \t  '-4.56 hours' \t  ", Constant(timedelta(hours=-4.56))),
+        ("now", NamedVariable(NamedVariableType.NOW)),
+        ("NOW", NamedVariable(NamedVariableType.NOW)),  # case insensitive
+        ("setMaxW", NamedVariable(NamedVariableType.DERSETTING_SET_MAX_W)),
+        ("SETMAXW", NamedVariable(NamedVariableType.DERSETTING_SET_MAX_W)),  # case insensitive
+        ("foo", UnparseableVariableExpressionError),  # unknown named variable
+        (
+            "0.5 * 0.2",
+            Expression(OperationType.MULTIPLY, Constant(0.5), Constant(0.2)),
+        ),
+        (
+            "0.5 * setMaxW",
+            Expression(OperationType.MULTIPLY, Constant(0.5), NamedVariable(NamedVariableType.DERSETTING_SET_MAX_W)),
+        ),
+        (
+            "setMaxW / 2",
+            Expression(OperationType.DIVIDE, NamedVariable(NamedVariableType.DERSETTING_SET_MAX_W), Constant(2)),
+        ),
+        (
+            "  now  -    '-12   minutes'  ",
+            Expression(OperationType.SUBTRACT, NamedVariable(NamedVariableType.NOW), Constant(timedelta(minutes=-12))),
+        ),
+        (
+            "now-'-12minutes'",
+            Expression(OperationType.SUBTRACT, NamedVariable(NamedVariableType.NOW), Constant(timedelta(minutes=-12))),
+        ),
+        (
+            'now + "3 day"',
+            Expression(OperationType.ADD, NamedVariable(NamedVariableType.NOW), Constant(timedelta(days=3))),
+        ),
+        ("now + foo", UnparseableVariableExpressionError),
+        ("now foo +", UnparseableVariableExpressionError),
+        ("now foo ", UnparseableVariableExpressionError),
+        ("7 + + 8 ", UnparseableVariableExpressionError),
+        ("'5 mins + now ", UnparseableVariableExpressionError),  # Unterminated string literal
+        ("now + '5 mins", UnparseableVariableExpressionError),  # Unterminated string literal
+    ],
+)
+def test_parse_variable_expression_body(
+    var_body: str, expected: type[Exception] | NamedVariable | Constant | Expression
+):
+    """Top level parsing test to ensure that a variety of variable bodies parse (or fail) in an expected fashion"""
+
+    if isinstance(expected, type):
+        with pytest.raises(expected):
+            parse_variable_expression_body(var_body)
+    else:
+        actual = parse_variable_expression_body(var_body)
+        assert isinstance(actual, NamedVariable) or isinstance(actual, Constant) or isinstance(actual, Expression)
+        assert actual == expected, f"Input string: {var_body}"


### PR DESCRIPTION
Actions can now specify parameters that can utilise some basic expressions. Eg referencing the current datetime $(now).

These "variable expressions" will encode as a `Expression` / `NamedVariable` object which the Cactus Runner will need to resolve at the appropriate time. Likely in `event.py` around the `_apply_action`.

Some examples:

`$(now - '5 minutes')` : When resolved should become a timestamp 5 minutes in the past
`$(0.5 * setMaxW)` : When resolved should be a number set to half the value of the DERSettings.setMaxW