### PR TITLE
Update precondition checks

### DIFF
--- a/cactus_test_definitions/procedures/ALL-03.yaml
+++ b/cactus_test_definitions/procedures/ALL-03.yaml
@@ -14,6 +14,11 @@ Criteria:
     - type: der-status-contents
       parameters: {}
 
+Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
+
 Steps:
   GET-REGISTRATION:
     event:

--- a/cactus_test_definitions/procedures/ALL-05.yaml
+++ b/cactus_test_definitions/procedures/ALL-05.yaml
@@ -23,6 +23,9 @@ Criteria:
       parameters: {"minimum_count": 7}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/ALL-06.yaml
+++ b/cactus_test_definitions/procedures/ALL-06.yaml
@@ -7,7 +7,12 @@ Criteria:
   checks:
     - type: all-steps-complete
       parameters: {}
-    
+
+Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
+
 Steps:
   
   POST-DERSTATUS-DISCONNECT:

--- a/cactus_test_definitions/procedures/ALL-07.yaml
+++ b/cactus_test_definitions/procedures/ALL-07.yaml
@@ -8,6 +8,11 @@ Criteria:
     - type: all-steps-complete
       parameters: {}
     
+Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
+      
 Steps:
   
   POST-DERSTATUS-DISCONNECT:

--- a/cactus_test_definitions/procedures/ALL-08.yaml
+++ b/cactus_test_definitions/procedures/ALL-08.yaml
@@ -14,6 +14,11 @@ Criteria:
     - type: der-status-contents
       parameters: {}
 
+Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
+
 Steps:
   
   GET-DER:

--- a/cactus_test_definitions/procedures/ALL-09.yaml
+++ b/cactus_test_definitions/procedures/ALL-09.yaml
@@ -21,6 +21,10 @@ Criteria:
     - type: readings-der-voltage
       parameters: {"minimum_count": 3}
 
+Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
 
 Steps:
   

--- a/cactus_test_definitions/procedures/ALL-10.yaml
+++ b/cactus_test_definitions/procedures/ALL-10.yaml
@@ -9,6 +9,9 @@ Criteria:
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/ALL-11.yaml
+++ b/cactus_test_definitions/procedures/ALL-11.yaml
@@ -9,6 +9,9 @@ Criteria:
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/ALL-12.yaml
+++ b/cactus_test_definitions/procedures/ALL-12.yaml
@@ -9,6 +9,9 @@ Criteria:
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-default-der-control
       parameters:

--- a/cactus_test_definitions/procedures/ALL-13.yaml
+++ b/cactus_test_definitions/procedures/ALL-13.yaml
@@ -11,6 +11,9 @@ Criteria:
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: register-end-device
       parameters: {}

--- a/cactus_test_definitions/procedures/ALL-14.yaml
+++ b/cactus_test_definitions/procedures/ALL-14.yaml
@@ -12,9 +12,10 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         # Set this to a large value - we want to test they respond due to notification - not polling

--- a/cactus_test_definitions/procedures/ALL-15.yaml
+++ b/cactus_test_definitions/procedures/ALL-15.yaml
@@ -12,9 +12,10 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         # Set this to a large value - we want to test they respond due to notification - not polling

--- a/cactus_test_definitions/procedures/ALL-16.yaml
+++ b/cactus_test_definitions/procedures/ALL-16.yaml
@@ -12,9 +12,10 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         # Set this to a large value - we want to test they respond due to notification - not polling

--- a/cactus_test_definitions/procedures/ALL-17.yaml
+++ b/cactus_test_definitions/procedures/ALL-17.yaml
@@ -9,9 +9,10 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         derp_list_poll_seconds: 60

--- a/cactus_test_definitions/procedures/ALL-17.yaml
+++ b/cactus_test_definitions/procedures/ALL-17.yaml
@@ -12,6 +12,8 @@ Preconditions:
   checks:
     - type: end-device-contents
       parameters: {}
+    - type: der-settings-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/ALL-18.yaml
+++ b/cactus_test_definitions/procedures/ALL-18.yaml
@@ -10,9 +10,10 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         fsa_list_poll_seconds: 300

--- a/cactus_test_definitions/procedures/ALL-19.yaml
+++ b/cactus_test_definitions/procedures/ALL-19.yaml
@@ -9,9 +9,10 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         fsa_list_poll_seconds: 120

--- a/cactus_test_definitions/procedures/ALL-20.yaml
+++ b/cactus_test_definitions/procedures/ALL-20.yaml
@@ -12,6 +12,8 @@ Preconditions:
   checks:
     - type: end-device-contents
       parameters: {}
+    - type: der-settings-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/ALL-22.yaml
+++ b/cactus_test_definitions/procedures/ALL-22.yaml
@@ -12,6 +12,8 @@ Preconditions:
   checks:
     - type: end-device-contents
       parameters: {}
+    - type: der-settings-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/ALL-23.yaml
+++ b/cactus_test_definitions/procedures/ALL-23.yaml
@@ -12,6 +12,8 @@ Preconditions:
   checks:
     - type: end-device-contents
       parameters: {}
+    - type: der-settings-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/ALL-23.yaml
+++ b/cactus_test_definitions/procedures/ALL-23.yaml
@@ -9,6 +9,9 @@ Criteria:
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/ALL-29.yaml
+++ b/cactus_test_definitions/procedures/ALL-29.yaml
@@ -12,7 +12,8 @@ Preconditions:
   checks:
     - type: end-device-contents
       parameters: {}
-
+    - type: der-settings-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/GEN-01.yaml
+++ b/cactus_test_definitions/procedures/GEN-01.yaml
@@ -9,6 +9,9 @@ Criteria:
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/GEN-02.yaml
+++ b/cactus_test_definitions/procedures/GEN-02.yaml
@@ -9,6 +9,9 @@ Criteria:
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/GEN-03.yaml
+++ b/cactus_test_definitions/procedures/GEN-03.yaml
@@ -9,6 +9,9 @@ Criteria:
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/GEN-04.yaml
+++ b/cactus_test_definitions/procedures/GEN-04.yaml
@@ -12,6 +12,8 @@ Preconditions:
   checks:
     - type: end-device-contents
       parameters: {}
+    - type: der-settings-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/GEN-04.yaml
+++ b/cactus_test_definitions/procedures/GEN-04.yaml
@@ -9,6 +9,9 @@ Criteria:
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/GEN-05.yaml
+++ b/cactus_test_definitions/procedures/GEN-05.yaml
@@ -12,9 +12,10 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         # Set this to a large value - we want to test they respond due to notification - not polling

--- a/cactus_test_definitions/procedures/GEN-06.yaml
+++ b/cactus_test_definitions/procedures/GEN-06.yaml
@@ -15,6 +15,8 @@ Preconditions:
   checks:
     - type: end-device-contents
       parameters: {}
+    - type: der-settings-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/GEN-06.yaml
+++ b/cactus_test_definitions/procedures/GEN-06.yaml
@@ -12,9 +12,10 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         # Set this to a large value - we want to test they respond due to notification - not polling

--- a/cactus_test_definitions/procedures/GEN-07.yaml
+++ b/cactus_test_definitions/procedures/GEN-07.yaml
@@ -12,9 +12,10 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         # Set this to a large value - we want to test they respond due to notification - not polling

--- a/cactus_test_definitions/procedures/GEN-08.yaml
+++ b/cactus_test_definitions/procedures/GEN-08.yaml
@@ -15,6 +15,8 @@ Preconditions:
   checks:
     - type: end-device-contents
       parameters: {}
+    - type: der-settings-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/GEN-08.yaml
+++ b/cactus_test_definitions/procedures/GEN-08.yaml
@@ -12,9 +12,10 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         # Set this to a large value - we want to test they respond due to notification - not polling

--- a/cactus_test_definitions/procedures/LOA-01.yaml
+++ b/cactus_test_definitions/procedures/LOA-01.yaml
@@ -9,6 +9,9 @@ Criteria:
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/LOA-02.yaml
+++ b/cactus_test_definitions/procedures/LOA-02.yaml
@@ -9,6 +9,9 @@ Criteria:
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/LOA-03.yaml
+++ b/cactus_test_definitions/procedures/LOA-03.yaml
@@ -12,6 +12,8 @@ Preconditions:
   checks:
     - type: end-device-contents
       parameters: {}
+    - type: der-settings-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/LOA-03.yaml
+++ b/cactus_test_definitions/procedures/LOA-03.yaml
@@ -9,6 +9,9 @@ Criteria:
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/LOA-04.yaml
+++ b/cactus_test_definitions/procedures/LOA-04.yaml
@@ -9,6 +9,9 @@ Criteria:
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/LOA-05.yaml
+++ b/cactus_test_definitions/procedures/LOA-05.yaml
@@ -15,6 +15,8 @@ Preconditions:
   checks:
     - type: end-device-contents
       parameters: {}
+    - type: der-settings-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/LOA-05.yaml
+++ b/cactus_test_definitions/procedures/LOA-05.yaml
@@ -12,9 +12,10 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         # Set this to a large value - we want to test they respond due to notification - not polling

--- a/cactus_test_definitions/procedures/LOA-06.yaml
+++ b/cactus_test_definitions/procedures/LOA-06.yaml
@@ -12,9 +12,10 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         # Set this to a large value - we want to test they respond due to notification - not polling

--- a/cactus_test_definitions/procedures/LOA-07.yaml
+++ b/cactus_test_definitions/procedures/LOA-07.yaml
@@ -15,6 +15,8 @@ Preconditions:
   checks:
     - type: end-device-contents
       parameters: {}
+    - type: der-settings-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/LOA-07.yaml
+++ b/cactus_test_definitions/procedures/LOA-07.yaml
@@ -12,9 +12,10 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         # Set this to a large value - we want to test they respond due to notification - not polling

--- a/cactus_test_definitions/procedures/LOA-08.yaml
+++ b/cactus_test_definitions/procedures/LOA-08.yaml
@@ -12,9 +12,10 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         # Set this to a large value - we want to test they respond due to notification - not polling

--- a/cactus_test_definitions/procedures/MUL-01.yaml
+++ b/cactus_test_definitions/procedures/MUL-01.yaml
@@ -11,6 +11,8 @@ Criteria:
 
 Preconditions:
   checks:
+    - type: end-device-contents
+      parameters: {}
     - type: der-status-contents
       parameters: 
         genConnectStatus_bit0: true

--- a/cactus_test_definitions/procedures/MUL-01.yaml
+++ b/cactus_test_definitions/procedures/MUL-01.yaml
@@ -13,6 +13,8 @@ Preconditions:
   checks:
     - type: end-device-contents
       parameters: {}
+    - type: der-settings-contents
+      parameters: {}
     - type: der-status-contents
       parameters: 
         genConnectStatus_bit0: true

--- a/cactus_test_definitions/procedures/MUL-02.yaml
+++ b/cactus_test_definitions/procedures/MUL-02.yaml
@@ -26,6 +26,8 @@ Preconditions:
   checks:
     - type: end-device-contents
       parameters: {}
+    - type: der-settings-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/MUL-02.yaml
+++ b/cactus_test_definitions/procedures/MUL-02.yaml
@@ -23,6 +23,9 @@ Criteria:
       parameters: {"minimum_count": 3}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/MUL-03.yaml
+++ b/cactus_test_definitions/procedures/MUL-03.yaml
@@ -14,6 +14,11 @@ Criteria:
     - type: der-status-contents
       parameters: {}
 
+Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
+
 Steps:
   
   POST-DERSETTINGS-FIRST:

--- a/tests/unit/test_test_procedures.py
+++ b/tests/unit/test_test_procedures.py
@@ -115,3 +115,22 @@ def test_each_step_connected(tp_id: str, tp: TestProcedure):
     assert (
         step_names == visited_nodes
     ), "Missing entries here indicate a step (or steps) that can't be reached from the root node"
+
+@pytest.mark.parametrize("tp_id, tp", ALL_TEST_PROCEDURES)
+def test_procedures_have_required_preconditions(tp_id: str, tp: TestProcedure):
+
+    # Check 'end-device-contents' present
+    enddevice_not_required = [
+        "ALL-01",  # Out-of-band device registration
+        "ALL-02",  # In-band registration during test procedure
+        "OPT-1-IN-BAND", # In-band device registration during test procedure
+        "OPT-1-OUT-OF-BAND",  # Out-of-band device registration
+        "ALL-04"  # In-band device registration during test procedure
+    ]
+    if tp_id not in enddevice_not_required:
+        assert tp.preconditions is not None
+        assert tp.preconditions.checks is not None 
+        assert any([check.type == 'end-device-contents' for check in tp.preconditions.checks])
+
+    # Check 'der-settings-contents' present if precondition action references setMaxW
+    pass

--- a/tests/unit/test_test_procedures.py
+++ b/tests/unit/test_test_procedures.py
@@ -1,3 +1,4 @@
+from cactus_test_definitions.variable_expressions import Expression
 import pytest
 from cactus_test_definitions.test_procedures import (
     TestProcedure,
@@ -132,5 +133,10 @@ def test_procedures_have_required_preconditions(tp_id: str, tp: TestProcedure):
         assert tp.preconditions.checks is not None 
         assert any([check.type == 'end-device-contents' for check in tp.preconditions.checks])
 
-    # Check 'der-settings-contents' present if precondition action references setMaxW
-    pass
+    # Check 'der-settings-contents' present if precondition action involves "opModImpLimW" or "opModGenLimW" expression parameters. NOTE: It is assumed that the expressions with be expressed in terms of setMaxW - we do not perform this check explicitly.
+    if tp.preconditions is not None and tp.preconditions.actions is not None:
+        for action in tp.preconditions.actions:
+            if action.type == "create-der-control" and action.parameters is not None:
+                if ("opModImpLimW" in action.parameters and type(action.parameters["opModImpLimW"]) == Expression) or ("opModGenLimW" in action.parameters and type(action.parameters["opModGenLimW"]) == Expression):
+                    assert tp.preconditions.checks is not None
+                    assert any([check.type == 'der-settings-contents' for check in tp.preconditions.checks])


### PR DESCRIPTION
Adds a unit test to verify test procedures that require the `end-device-contents` and `der-settings-contents` precondition checks in fact have them.

Updates test procedures to ensure compliance with this unit test.