### PR TITLE
Fix connection point registration as PUT

### DIFF
--- a/cactus_test_definitions/procedures/OPT-1-IN-BAND.yaml
+++ b/cactus_test_definitions/procedures/OPT-1-IN-BAND.yaml
@@ -70,7 +70,7 @@ Steps:
         parameters:
           steps:
             - GET-DER
-            - POST-CP
+            - PUT-CP
       - type: remove-steps
         parameters:
           steps:
@@ -87,13 +87,13 @@ Steps:
           steps:
             - GET-DER
 
-  POST-CP:
+  PUT-CP:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/cp
     actions:
       - type: remove-steps
         parameters:
           steps:
-            - POST-CP
+            - PUT-CP

--- a/cactus_test_definitions/procedures/OPT-1-OUT-OF-BAND.yaml
+++ b/cactus_test_definitions/procedures/OPT-1-OUT-OF-BAND.yaml
@@ -30,7 +30,7 @@ Steps:
             - GET-EDEV-LIST
             - GET-TM
             - GET-DER
-            - POST-CP
+            - PUT-CP
       - type: remove-steps
         parameters:
           steps:
@@ -69,13 +69,13 @@ Steps:
           steps:
             - GET-DER
 
-  POST-CP:
+  PUT-CP:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/cp
     actions:
       - type: remove-steps
         parameters:
           steps:
-            - POST-CP
+            - PUT-CP


### PR DESCRIPTION
From the [CSIP-AUS version 1.1a](https://www.csipaus.org/s/common-smart-inverter-profile-australia.pdf) doc, connection point is a PUT rather than a POST

> ConnectionPoint resource extension
> Sample URI: /edev/{id1}/cp
> Request representation: ConnectionPoint
> Response representation: ConnectionPoint
> Methods: GET/HEAD: Mandatory, PUT: Mandatory, POST: Error, DELETE: Error

> Updates
> Where this extension is used, the server shall support updates to ConnectionPoint identifier through a
> PUT request. This may be used, for instance, to correct an incorrectly entered identifier.

> To inform the network of the location of the device on the network with respect to its
> connection point, the aggregator PUTs to /edev/{edevLocation}/cp.
> PUT /edev/4/cp HTTP/1.1
> Host: {hostname}
> Content-Type: application/sep+xml Content-Length:
> {contentLength}
> <csipaus:ConnectionPoint
> xmlns:csipaus=”https://csipaus.org/ns”>
>  <csipaus:connectionPointId>1234567890
> </csipaus:connectionPointId>
> </csipaus:ConnectionPoint>