### PR TITLE
feat: 197946 merge storage extension with main

### DIFF
--- a/.github/workflows/linttest.yml
+++ b/.github/workflows/linttest.yml
@@ -1,9 +1,9 @@
 name: Linting and Testing
 on:
   push:
-    branches: [main]
+    branches: [main, csipaus.org/ns/v1.3-beta/storage]
   pull_request:
-    branches: [main]
+    branches: [main, csipaus.org/ns/v1.3-beta/storage]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/linttest.yml
+++ b/.github/workflows/linttest.yml
@@ -1,9 +1,9 @@
 name: Linting and Testing
 on:
   push:
-    branches: [main, csipaus.org/ns/v1.3-beta/storage]
+    branches: [main]
   pull_request:
-    branches: [main, csipaus.org/ns/v1.3-beta/storage]
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# Cactus Test Definitions - Forked for Synergy Storage Extension
+
+This is a forked project with a long lived branch which implements the CSIP-Aus storage extension (https://csipaus.org/ns/v1.3-beta/storage) proposed by Synergy
+
+The original project, which focuses implementation on the current accepted CSIP-Aus standards, is developed by [BSGIP here](https://github.com/bsgip/cactus-test-definitions)
+
+<br>
+
 # Cactus Test Definitions
 
 This repository contains YAML test procedure definitions for use with the CSIP-AUS Client Test Harness.
@@ -108,8 +116,8 @@ actions:
 | `enable-steps` | `steps: list[str]` | The names of `Step`'s that will be activated |
 | `remove-steps` | `steps: list[str]` | The names of `Step`'s that will be deactivated (if active) |
 | `finish-test` | None | When activated, the current test will be finished (shutdown) and all `Criteria` evaluated as if the client had requested finalization. |
-| `set-default-der-control` | `derp_id: int/None` `opModImpLimW: float/None` `opModExpLimW: float/None` `opModLoadLimW: float/None` `setGradW: float/None` `cancelled: bool/None` | Updates the DefaultDERControl's parameters with the specified values. If `cancelled` is `true`, all unspecified values will be set to None. If `derp_id` is specified, this will apply to the DERProgram with that value, otherwise it will apply to all DERPrograms |
-| `create-der-control` | `start: datetime` `duration_seconds: int` `pow_10_multipliers: int/None` `primacy: int/None` `fsa_id: int/None` `randomizeStart_seconds: int/None` `ramp_time_seconds: float/None` `opModEnergize: bool/None` `opModConnect: bool/None` `opModImpLimW: float/None` `opModExpLimW: float/None` `opModGenLimW: float/None` `opModLoadLimW: float/None` `opModFixedW: float/None` | Creates a DERControl with the specified start/duration and values. A new DERProgram will be created with primacy (and optionally under FunctionSetAssignment `fsa_id`) if no such DERProgram already exists |
+| `set-default-der-control` | `derp_id: int/None` `opModImpLimW: float/None` `opModExpLimW: float/None` `opModLoadLimW: float/None` `setGradW: float/None` `cancelled: bool/None` `opModStorageTargetW: float/None` | Updates the DefaultDERControl's parameters with the specified values. If `cancelled` is `true`, all unspecified values will be set to None. If `derp_id` is specified, this will apply to the DERProgram with that value, otherwise it will apply to all DERPrograms |
+| `create-der-control` | `start: datetime` `duration_seconds: int` `pow_10_multipliers: int/None` `primacy: int/None` `fsa_id: int/None` `randomizeStart_seconds: int/None` `ramp_time_seconds: float/None` `opModEnergize: bool/None` `opModConnect: bool/None` `opModImpLimW: float/None` `opModExpLimW: float/None` `opModGenLimW: float/None` `opModLoadLimW: float/None` `opModFixedW: float/None` `opModStorageTargetW: float/None` | Creates a DERControl with the specified start/duration and values. A new DERProgram will be created with primacy (and optionally under FunctionSetAssignment `fsa_id`) if no such DERProgram already exists |
 | `create-der-program` | `primacy: int` `fsa_id: int/None` | Creates a DERProgram with the specified primacy. Will be assigned under FunctionSetAssignment 1 unless `fsa_id` says otherwise. |
 | `cancel-active-der-controls` | None | Cancels all active DERControls |
 | `set-comms-rate` | `dcap_poll_seconds: int/None` `edev_post_seconds: int/None` `edev_list_poll_seconds: int/None` `fsa_list_poll_seconds: int/None` `derp_list_poll_seconds: int/None` `der_list_poll_seconds: int/None` `mup_post_seconds: int/None` | Updates one or more post/poll rates for various resources. For non list resources, the rate will apply to all resources. Unspecified values will not update existing server values. |
@@ -146,8 +154,8 @@ checks:
 | `all-steps-complete` | `ignored_steps: list[str]/None` | True if every `Step` in a `TestProcedure` has been deactivated (excepting any ignored steps) |
 | `all-notifications-transmitted` | None | True if every transmitted notification (pub/sub) has been received with a HTTP success code response from the subscription notification URI |
 | `end-device-contents` | `has_connection_point_id: bool/None` | True if an `EndDevice` is registered and optionally has the specified contents. `has_connection_point_id` (if True) will check whether the active `EndDevice` has `ConnectionPoint.id` specified. |
-| `der-settings-contents` | `setGradW: int/None` `doeModesEnabled_set: hex/none` `doeModesEnabled_unset: hex/none` `modesEnabled_set: hex/none` `modesEnabled_unset: hex/none` `setMaxVA: bool/none` `setMaxVar: bool/none` `setMaxW: bool/none` `setMaxChargeRateW: bool/none` `setMaxDischargeRateW: bool/none` `setMaxWh: bool/none` | True if a `DERSettings` has been set for the `EndDevice` under test (and if certain elements have been set to certain values) |
-| `der-capability-contents` | `doeModesSupported_set: hex/none` `doeModesSupported_unset: hex/none` `modesSupported_set: hex/none` `modesSupported_unset: hex/none` `rtgMaxVA: bool/none` `rtgMaxVar: bool/none` `rtgMaxW: bool/none` `rtgMaxChargeRateW: bool/none` `rtgMaxDischargeRateW: bool/none` `rtgMaxWh: bool/none` | True if a `DERCapability` has been set for the `EndDevice` under test (and if certain elements have been set to certain values) |
+| `der-settings-contents` | `setGradW: int/None` `doeModesEnabled_set: hex/none` `doeModesEnabled_unset: hex/none` `modesEnabled_set: hex/none` `modesEnabled_unset: hex/none` `setMaxVA: bool/none` `setMaxVar: bool/none` `setMaxW: bool/none` `setMaxChargeRateW: bool/none` `setMaxDischargeRateW: bool/none` `setMaxWh: bool/none` `setMinWh: bool/none` `vppModesEnabled_set: hexbinary/none` `vppModesEnabled_unset: hexbinary/none` | True if a `DERSettings` has been set for the `EndDevice` under test (and if certain elements have been set to certain values) |
+| `der-capability-contents` | `doeModesSupported_set: hex/none` `doeModesSupported_unset: hex/none` `modesSupported_set: hex/none` `modesSupported_unset: hex/none` `rtgMaxVA: bool/none` `rtgMaxVar: bool/none` `rtgMaxW: bool/none` `rtgMaxChargeRateW: bool/none` `rtgMaxDischargeRateW: bool/none` `rtgMaxWh: bool/none` `vppModesSupported_set: hexbinary/none` `vppModesSupported_unset: hexbinary/none` | True if a `DERCapability` has been set for the `EndDevice` under test (and if certain elements have been set to certain values) |
 | `der-status-contents` | `genConnectStatus: int/None` `operationalModeStatus: int/None` | True if a `DERStatus` has been set for the `EndDevice` under test (and if certain elements have been set to certain values) |
 | `readings-site-active-power` | `minimum_count: int` | True if MUP for site wide active power has `minimum_count` entries |
 | `readings-site-reactive-power` | `minimum_count: int` | True if MUP for site wide reactive power has `minimum_count` entries |
@@ -203,6 +211,12 @@ The following are all the `NamedVariable` types currently implemented
 | `$rtgMaxChargeRateW` | Resolves to last supplied `DERCapability.rtgMaxChargeRateW` as a number. Raises exceptions if value hasn't been set, causing test to fail.
 | `$rtgMaxDischargeRateW` | Resolves to last supplied `DERCapability.rtgMaxDischargeRateW` as a number. Raises exceptions if value hasn't been set, causing test to fail.
 | `$rtgMaxWh` | Resolves to last supplied `DERCapability.rtgMaxWh` as a number. Raises exceptions if value hasn't been set, causing test to fail.
+
+The following are csipaus.org/ns/v1.3-beta/storage extension specific `NamedVariable` types implemented
+
+| **name** | **description** |
+| -------- | --------------- |
+| `$setMinWh` | Resolves to the last supplied value to `DERSetting.setMinWh` as a number. Can raise exceptions if this value hasn't been set (which will trigger a test evaluation to fail)
 
 
 Placeholder variables can also be used in some rudimentary expressions to make variations on the returned value. For example:

--- a/README.md
+++ b/README.md
@@ -165,6 +165,13 @@ checks:
 | `readings-der-voltage` | `minimum_count: int` | True if MUP for DER voltage has `minimum_count` entries |
 | `response-contents` | `latest: bool/None` `status: int/None` | True if at least one received Response matches the filter. `latest` will only consider the most recent received Response.  |
 
+The following are csipaus.org/ns/v1.3-beta/storage extension specific checks implemented
+
+| **name** | **params** | **description** |
+| -------- | ---------- | --------------- |
+| `readings-der-stored-energy` | `minimum_count: int` | True if MUP for DER stored energy has `minimum_count` entries |
+<br>
+
 #### Hexbinary Parameters for Bitwise Operations
 `doeModesEnabled_set` `modesEnabled_set` `doeModesSupported_set` and `modesSupported_set` all expect a hexbinary string to be supplied, which contains the hi assertion bits to be equal to one e.g. `doeModesEnabled_set: "03"` would test to ensure that at least bits 0 and 1 are set hi (==1) for the given `DERSetting.doeModesEnabled`, ignoring all others
 The corresponding `_unset` performs the inverse operation such that every bit set to 1 in the mask is expected to correspond to a zero in the corresponding value e.g. `doeModesEnabled_unset: "03"` would test to ensure that at least bits 0 and 1 are set lo (==0) for the given `DERSetting.doeModesEnabled`, ignoring all others

--- a/README.md
+++ b/README.md
@@ -1,11 +1,3 @@
-# Cactus Test Definitions - Forked for Synergy Storage Extension
-
-This is a forked project with a long lived branch which implements the CSIP-Aus storage extension (https://csipaus.org/ns/v1.3-beta/storage) proposed by Synergy
-
-The original project, which focuses implementation on the current accepted CSIP-Aus standards, is developed by [BSGIP here](https://github.com/bsgip/cactus-test-definitions)
-
-<br>
-
 # Cactus Test Definitions
 
 This repository contains YAML test procedure definitions for use with the CSIP-AUS Client Test Harness.
@@ -153,23 +145,23 @@ checks:
 | -------- | ---------- | --------------- |
 | `all-steps-complete` | `ignored_steps: list[str]/None` | True if every `Step` in a `TestProcedure` has been deactivated (excepting any ignored steps) |
 | `all-notifications-transmitted` | None | True if every transmitted notification (pub/sub) has been received with a HTTP success code response from the subscription notification URI |
-| `end-device-contents` | `has_connection_point_id: bool/None` | True if an `EndDevice` is registered and optionally has the specified contents. `has_connection_point_id` (if True) will check whether the active `EndDevice` has `ConnectionPoint.id` specified. |
+| `end-device-contents` | `has_connection_point_id: bool/None` `deviceCategory_anyset: hex/none` | True if an `EndDevice` is registered and optionally has the specified contents. `has_connection_point_id` (if True) will check whether the active `EndDevice` has `ConnectionPoint.id` specified. |
 | `der-settings-contents` | `setGradW: int/None` `doeModesEnabled_set: hex/none` `doeModesEnabled_unset: hex/none` `modesEnabled_set: hex/none` `modesEnabled_unset: hex/none` `setMaxVA: bool/none` `setMaxVar: bool/none` `setMaxW: bool/none` `setMaxChargeRateW: bool/none` `setMaxDischargeRateW: bool/none` `setMaxWh: bool/none` `setMinWh: bool/none` `vppModesEnabled_set: hexbinary/none` `vppModesEnabled_unset: hexbinary/none` | True if a `DERSettings` has been set for the `EndDevice` under test (and if certain elements have been set to certain values) |
 | `der-capability-contents` | `doeModesSupported_set: hex/none` `doeModesSupported_unset: hex/none` `modesSupported_set: hex/none` `modesSupported_unset: hex/none` `rtgMaxVA: bool/none` `rtgMaxVar: bool/none` `rtgMaxW: bool/none` `rtgMaxChargeRateW: bool/none` `rtgMaxDischargeRateW: bool/none` `rtgMaxWh: bool/none` `vppModesSupported_set: hexbinary/none` `vppModesSupported_unset: hexbinary/none` | True if a `DERCapability` has been set for the `EndDevice` under test (and if certain elements have been set to certain values) |
-| `der-status-contents` | `genConnectStatus: int/None` `operationalModeStatus: int/None` | True if a `DERStatus` has been set for the `EndDevice` under test (and if certain elements have been set to certain values) |
-| `readings-site-active-power` | `minimum_count: int` | True if MUP for site wide active power has `minimum_count` entries |
-| `readings-site-reactive-power` | `minimum_count: int` | True if MUP for site wide reactive power has `minimum_count` entries |
-| `readings-site-voltage` | `minimum_count: int` | True if MUP for site wide voltage has `minimum_count` entries |
-| `readings-der-active-power` | `minimum_count: int` | True if MUP for DER active power has `minimum_count` entries |
-| `readings-der-reactive-power` | `minimum_count: int` | True if MUP for DER reactive power has `minimum_count` entries |
-| `readings-der-voltage` | `minimum_count: int` | True if MUP for DER voltage has `minimum_count` entries |
+| `der-status-contents` | `genConnectStatus: int/None` `operationalModeStatus: int/None` `alarmStatus: int/None` | True if a `DERStatus` has been set for the `EndDevice` under test (and if certain elements have been set to certain values) |
+| `readings-site-active-power` | `minimum_count: int` | True if any MirrorUsagePoint has a MirrorMeterReading for site wide active power with `minimum_count` entries |
+| `readings-site-reactive-power` | `minimum_count: int` | True if any MirrorUsagePoint has a MirrorMeterReading for site wide reactive power with `minimum_count` entries |
+| `readings-site-voltage` | `minimum_count: int` | True if any MirrorUsagePoint has a MirrorMeterReading for site wide voltage with `minimum_count` entries |
+| `readings-der-active-power` | `minimum_count: int` | True if any MirrorUsagePoint has a MirrorMeterReading for DER active power with `minimum_count` entries |
+| `readings-der-reactive-power` | `minimum_count: int` | True if any MirrorUsagePoint has a MirrorMeterReading for DER reactive power with `minimum_count` entries |
+| `readings-der-voltage` | `minimum_count: int` | True if any MirrorUsagePoint has a MirrorMeterReading for DER voltage with `minimum_count` entries |
 | `response-contents` | `latest: bool/None` `status: int/None` | True if at least one received Response matches the filter. `latest` will only consider the most recent received Response.  |
 
 The following are csipaus.org/ns/v1.3-beta/storage extension specific checks implemented
 
 | **name** | **params** | **description** |
 | -------- | ---------- | --------------- |
-| `readings-der-stored-energy` | `minimum_count: int` | True if MUP for DER stored energy has `minimum_count` entries |
+| `readings-der-stored-energy` | `minimum_count: int` | True if any MirrorUsagePoint has a MirrorMeterReading for DER stored energy with `minimum_count` entries |
 <br>
 
 #### Hexbinary Parameters for Bitwise Operations

--- a/cactus_test_definitions/__init__.py
+++ b/cactus_test_definitions/__init__.py
@@ -7,6 +7,7 @@ from cactus_test_definitions.errors import (
 )
 from cactus_test_definitions.events import EVENT_PARAMETER_SCHEMA, Event
 from cactus_test_definitions.test_procedures import (
+    CSIPAusVersion,
     Preconditions,
     Step,
     TestProcedure,
@@ -38,6 +39,7 @@ __all__ = [
     "ACTION_PARAMETER_SCHEMA",
     "Check",
     "CHECK_PARAMETER_SCHEMA",
+    "CSIPAusVersion",
     "EVENT_PARAMETER_SCHEMA",
     "Step",
     "Preconditions",

--- a/cactus_test_definitions/actions.py
+++ b/cactus_test_definitions/actions.py
@@ -38,6 +38,7 @@ ACTION_PARAMETER_SCHEMA: dict[str, dict[str, ParameterSchema]] = {
         "opModExpLimW": ParameterSchema(False, ParameterType.Float),
         "opModGenLimW": ParameterSchema(False, ParameterType.Float),
         "opModLoadLimW": ParameterSchema(False, ParameterType.Float),
+        "opModStorageTargetW": ParameterSchema(False, ParameterType.Float),
         "setGradW": ParameterSchema(False, ParameterType.Integer),  # Hundredths of a percent / second
         "cancelled": ParameterSchema(False, ParameterType.Boolean),
     },
@@ -56,6 +57,7 @@ ACTION_PARAMETER_SCHEMA: dict[str, dict[str, ParameterSchema]] = {
         "opModGenLimW": ParameterSchema(False, ParameterType.Float),
         "opModLoadLimW": ParameterSchema(False, ParameterType.Float),
         "opModFixedW": ParameterSchema(False, ParameterType.Float),
+        "opModStorageTargetW": ParameterSchema(False, ParameterType.Float),
     },
     "create-der-program": {
         "primacy": ParameterSchema(True, ParameterType.Integer),

--- a/cactus_test_definitions/checks.py
+++ b/cactus_test_definitions/checks.py
@@ -39,6 +39,7 @@ CHECK_PARAMETER_SCHEMA: dict[str, dict[str, ParameterSchema]] = {
     "all-notifications-transmitted": {},
     "end-device-contents": {
         "has_connection_point_id": ParameterSchema(False, ParameterType.Boolean),
+        "deviceCategory_anyset": ParameterSchema(False, ParameterType.HexBinary),  # Any of these bits set to 1
     },
     "der-settings-contents": {
         "setGradW": ParameterSchema(False, ParameterType.Integer),  # Hundredths of a percent / second
@@ -79,7 +80,8 @@ CHECK_PARAMETER_SCHEMA: dict[str, dict[str, ParameterSchema]] = {
         "genConnectStatus_bit0": ParameterSchema(False, ParameterType.Boolean),
         "genConnectStatus_bit1": ParameterSchema(False, ParameterType.Boolean),
         "genConnectStatus_bit2": ParameterSchema(False, ParameterType.Boolean),
-        "operationalModeStatus": ParameterSchema(False, ParameterType.Boolean),
+        "operationalModeStatus": ParameterSchema(False, ParameterType.Integer),
+        "alarmStatus": ParameterSchema(False, ParameterType.Integer),
     },
     "readings-site-active-power": {"minimum_count": ParameterSchema(True, ParameterType.Integer)},
     "readings-site-reactive-power": {"minimum_count": ParameterSchema(True, ParameterType.Integer)},

--- a/cactus_test_definitions/checks.py
+++ b/cactus_test_definitions/checks.py
@@ -87,6 +87,7 @@ CHECK_PARAMETER_SCHEMA: dict[str, dict[str, ParameterSchema]] = {
     "readings-der-active-power": {"minimum_count": ParameterSchema(True, ParameterType.Integer)},
     "readings-der-reactive-power": {"minimum_count": ParameterSchema(True, ParameterType.Integer)},
     "readings-der-voltage": {"minimum_count": ParameterSchema(True, ParameterType.Integer)},
+    "readings-der-stored-energy": {"minimum_count": ParameterSchema(True, ParameterType.Integer)},  # Storage extension
     "subscription-contents": {"subscribed_resource": ParameterSchema(True, ParameterType.String)},
     "response-contents": {
         "latest": ParameterSchema(False, ParameterType.Boolean),

--- a/cactus_test_definitions/checks.py
+++ b/cactus_test_definitions/checks.py
@@ -46,18 +46,23 @@ CHECK_PARAMETER_SCHEMA: dict[str, dict[str, ParameterSchema]] = {
         "doeModesEnabled_unset": ParameterSchema(False, ParameterType.HexBinary),  # Minimum bits set to zero
         "modesEnabled_set": ParameterSchema(False, ParameterType.HexBinary),  # Minimum bits set to one
         "modesEnabled_unset": ParameterSchema(False, ParameterType.HexBinary),  # Minimum bits set to zero
+        "vppModesEnabled_set": ParameterSchema(False, ParameterType.HexBinary),  # Minimum bits set to one
+        "vppModesEnabled_unset": ParameterSchema(False, ParameterType.HexBinary),  # Minimum bits set to zero
         "setMaxVA": ParameterSchema(False, ParameterType.Boolean),  # Expected expression that evaluates to boolean
         "setMaxVar": ParameterSchema(False, ParameterType.Boolean),  # Expected expression that evaluates to boolean
         "setMaxW": ParameterSchema(False, ParameterType.Boolean),  # Expected expression that evaluates to boolean
         "setMaxChargeRateW": ParameterSchema(False, ParameterType.Boolean),
         "setMaxDischargeRateW": ParameterSchema(False, ParameterType.Boolean),
         "setMaxWh": ParameterSchema(False, ParameterType.Boolean),  # Expected expression that evaluates to boolean
+        "setMinWh": ParameterSchema(False, ParameterType.Boolean),  # Expected expression that evaluates to boolean
     },
     "der-capability-contents": {
         "doeModesSupported_set": ParameterSchema(False, ParameterType.HexBinary),  # Minimum bits set to one
         "doeModesSupported_unset": ParameterSchema(False, ParameterType.HexBinary),  # Minimum bits set to zero
         "modesSupported_set": ParameterSchema(False, ParameterType.HexBinary),  # Minimum bits set to one
         "modesSupported_unset": ParameterSchema(False, ParameterType.HexBinary),  # Minimum bits set to zero
+        "vppModesSupported_set": ParameterSchema(False, ParameterType.HexBinary),  # Minimum bits set to one
+        "vppModesSupported_unset": ParameterSchema(False, ParameterType.HexBinary),  # Minimum bits set to zero
         "rtgMaxVA": ParameterSchema(False, ParameterType.Boolean),  # Expected expression that evaluates to boolean
         "rtgMaxVar": ParameterSchema(False, ParameterType.Boolean),  # Expected expression that evaluates to boolean
         "rtgMaxW": ParameterSchema(False, ParameterType.Boolean),  # Expected expression that evaluates to boolean

--- a/cactus_test_definitions/procedures/ALL-01.yaml
+++ b/cactus_test_definitions/procedures/ALL-01.yaml
@@ -3,7 +3,11 @@ Category: Registration
 Classes:
   - A
   - DR-A
-  
+
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Preconditions:
   actions:
     - type: register-end-device

--- a/cactus_test_definitions/procedures/ALL-02.yaml
+++ b/cactus_test_definitions/procedures/ALL-02.yaml
@@ -4,6 +4,10 @@ Classes:
   - A
   - DR-A
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete

--- a/cactus_test_definitions/procedures/ALL-03.yaml
+++ b/cactus_test_definitions/procedures/ALL-03.yaml
@@ -2,7 +2,11 @@ Description: Client Registration and PIN Validation
 Category: Registration
 Classes:
   - A
-  
+
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -12,6 +16,11 @@ Criteria:
     - type: der-settings-contents
       parameters: {}
     - type: der-status-contents
+      parameters: {}
+
+Preconditions:
+  checks:
+    - type: end-device-contents
       parameters: {}
 
 Steps:

--- a/cactus_test_definitions/procedures/ALL-04.yaml
+++ b/cactus_test_definitions/procedures/ALL-04.yaml
@@ -3,6 +3,10 @@ Category: Registration
 Classes:
   - A
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Preconditions:
   actions:
     - type: 'edev-registration-links'

--- a/cactus_test_definitions/procedures/ALL-05.yaml
+++ b/cactus_test_definitions/procedures/ALL-05.yaml
@@ -3,6 +3,10 @@ Category: Monitoring
 Classes:
   - A
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -23,11 +27,17 @@ Criteria:
       parameters: {"minimum_count": 7}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:
         der_list_poll_seconds: 60
         mup_post_seconds: 60
+  instructions:
+    - Connect a test load electrically in parallel with the DER.
+    - Set the load to consume 25% of the DER's rated active power.
 
 Steps:
   GET-MUP:

--- a/cactus_test_definitions/procedures/ALL-06.yaml
+++ b/cactus_test_definitions/procedures/ALL-06.yaml
@@ -3,14 +3,25 @@ Category: Monitoring
 Classes:
   - A
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
       parameters: {}
-    
+
+Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
+
 Steps:
   
   POST-DERSTATUS-DISCONNECT:
+    instructions:
+      - Disconnect all DER from the grid.
     event:
       type: POST-request-received
       parameters:
@@ -32,6 +43,8 @@ Steps:
             - POST-DERSTATUS-DISCONNECT
   
   POST-DERSTATUS-CONNECT:
+    instructions:
+      - Reconnect all DER to the grid.
     event:
       type: POST-request-received
       parameters:

--- a/cactus_test_definitions/procedures/ALL-07.yaml
+++ b/cactus_test_definitions/procedures/ALL-07.yaml
@@ -3,14 +3,25 @@ Category: Monitoring
 Classes:
   - A
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
       parameters: {}
     
+Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
+      
 Steps:
   
   POST-DERSTATUS-DISCONNECT:
+    instructions:
+      - Stop DER from generating or consuming active power.
     event:
       type: POST-request-received
       parameters:
@@ -32,6 +43,8 @@ Steps:
             - POST-DERSTATUS-DISCONNECT
   
   POST-DERSTATUS-CONNECT:
+    instructions:
+      - Re-enable ability of DER to generate or consume active power.
     event:
       type: POST-request-received
       parameters:

--- a/cactus_test_definitions/procedures/ALL-08.yaml
+++ b/cactus_test_definitions/procedures/ALL-08.yaml
@@ -2,7 +2,11 @@ Description: Capabilities and Settings
 Category: Monitoring
 Classes:
   - A
-  
+
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -12,6 +16,11 @@ Criteria:
     - type: der-settings-contents
       parameters: {}
     - type: der-status-contents
+      parameters: {}
+
+Preconditions:
+  checks:
+    - type: end-device-contents
       parameters: {}
 
 Steps:

--- a/cactus_test_definitions/procedures/ALL-09.yaml
+++ b/cactus_test_definitions/procedures/ALL-09.yaml
@@ -3,6 +3,10 @@ Category: Monitoring
 Classes:
   - A
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -21,6 +25,10 @@ Criteria:
     - type: readings-der-voltage
       parameters: {"minimum_count": 3}
 
+Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
 
 Steps:
   

--- a/cactus_test_definitions/procedures/ALL-10.yaml
+++ b/cactus_test_definitions/procedures/ALL-10.yaml
@@ -3,12 +3,19 @@ Category: Control
 Classes:
   - A
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/ALL-11.yaml
+++ b/cactus_test_definitions/procedures/ALL-11.yaml
@@ -3,12 +3,19 @@ Category: Control
 Classes:
   - A
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/ALL-12.yaml
+++ b/cactus_test_definitions/procedures/ALL-12.yaml
@@ -3,12 +3,19 @@ Category: Control
 Classes:
   - A
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-default-der-control
       parameters:

--- a/cactus_test_definitions/procedures/ALL-13.yaml
+++ b/cactus_test_definitions/procedures/ALL-13.yaml
@@ -3,6 +3,10 @@ Category: Control
 Classes:
   - S
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -11,6 +15,9 @@ Criteria:
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: register-end-device
       parameters: {}
@@ -29,6 +36,8 @@ Steps:
 
   # Wait for a subscription to /edev and then update the active EndDevice's postRate to trigger a notification
   POST-SUBSCRIPTION-EDEV:
+    instructions:
+      - Trigger an EndDeviceList subscription request from the aggregator client system (this can be an automated response to completing the Discovery process).
     event:
       type: POST-request-received
       parameters:
@@ -49,6 +58,8 @@ Steps:
 
   # Wait for a subscription to /edev/1/fsa and then update the active fsa list to trigger a notification
   POST-SUBSCRIPTION-FSAL:
+    instructions:
+      - Trigger a FunctionSetAssignmentsList subscription request from the aggregator client system.
     event:
       type: POST-request-received
       parameters:
@@ -70,6 +81,8 @@ Steps:
 
   # Wait for a subscription to /edev/1/fsa/1/derp and then update the active DERProgram list to trigger a notification
   POST-SUBSCRIPTION-DERP:
+    instructions:
+      - Trigger a DERProgramList subscription request from the aggregator client system.
     event:
       type: POST-request-received
       parameters:
@@ -90,6 +103,8 @@ Steps:
 
   # Wait for a subscription to /edev/1/derp/1/derc and then create a DERControl to trigger a notification
   POST-SUBSCRIPTION-DERC:
+    instructions:
+      - Trigger a DERControlList subscription request from the aggregator client system.
     event:
       type: POST-request-received
       parameters:
@@ -113,6 +128,8 @@ Steps:
 
   # Wait for a subscription to /edev/1/derp/1/dderc and then update the DefaultDERControl to trigger a notification
   POST-SUBSCRIPTION-DEFAULT-DERC:
+    instructions:
+      - Trigger a DefaultDERControl subscription request from the aggregator client system.
     event:
       type: POST-request-received
       parameters:

--- a/cactus_test_definitions/procedures/ALL-14.yaml
+++ b/cactus_test_definitions/procedures/ALL-14.yaml
@@ -4,6 +4,10 @@ Classes:
   - A
   - S
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -12,9 +16,10 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         # Set this to a large value - we want to test they respond due to notification - not polling

--- a/cactus_test_definitions/procedures/ALL-15.yaml
+++ b/cactus_test_definitions/procedures/ALL-15.yaml
@@ -4,6 +4,10 @@ Classes:
   - A
   - S
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -12,9 +16,10 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         # Set this to a large value - we want to test they respond due to notification - not polling

--- a/cactus_test_definitions/procedures/ALL-16.yaml
+++ b/cactus_test_definitions/procedures/ALL-16.yaml
@@ -4,6 +4,10 @@ Classes:
   - A
   - S
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -12,9 +16,10 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         # Set this to a large value - we want to test they respond due to notification - not polling

--- a/cactus_test_definitions/procedures/ALL-17.yaml
+++ b/cactus_test_definitions/procedures/ALL-17.yaml
@@ -3,15 +3,22 @@ Category: Control
 Classes:
   - A
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+    - type: der-settings-contents
+      parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         derp_list_poll_seconds: 60

--- a/cactus_test_definitions/procedures/ALL-18.yaml
+++ b/cactus_test_definitions/procedures/ALL-18.yaml
@@ -4,15 +4,20 @@ Classes:
   - A
   - DR-A
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         fsa_list_poll_seconds: 300

--- a/cactus_test_definitions/procedures/ALL-19.yaml
+++ b/cactus_test_definitions/procedures/ALL-19.yaml
@@ -3,15 +3,20 @@ Category: Control
 Classes:
   - A
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         fsa_list_poll_seconds: 120

--- a/cactus_test_definitions/procedures/ALL-20.yaml
+++ b/cactus_test_definitions/procedures/ALL-20.yaml
@@ -3,6 +3,10 @@ Category: Control
 Classes:
   - A
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -11,6 +15,8 @@ Criteria:
 Preconditions:
   checks:
     - type: end-device-contents
+      parameters: {}
+    - type: der-settings-contents
       parameters: {}
   actions:
     - type: set-comms-rate

--- a/cactus_test_definitions/procedures/ALL-21.yaml
+++ b/cactus_test_definitions/procedures/ALL-21.yaml
@@ -3,6 +3,10 @@ Category: Control
 Classes:
   - A
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -11,6 +15,8 @@ Criteria:
 Preconditions:
   checks:
     - type: end-device-contents
+      parameters: {}
+    - type: der-settings-contents
       parameters: {}
   actions:
     - type: set-comms-rate

--- a/cactus_test_definitions/procedures/ALL-22.yaml
+++ b/cactus_test_definitions/procedures/ALL-22.yaml
@@ -3,6 +3,10 @@ Category: Control
 Classes:
   - A
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -11,6 +15,8 @@ Criteria:
 Preconditions:
   checks:
     - type: end-device-contents
+      parameters: {}
+    - type: der-settings-contents
       parameters: {}
   actions:
     - type: set-comms-rate

--- a/cactus_test_definitions/procedures/ALL-23.yaml
+++ b/cactus_test_definitions/procedures/ALL-23.yaml
@@ -3,12 +3,21 @@ Category: Control
 Classes:
   - A
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
+    - type: der-settings-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/ALL-25.yaml
+++ b/cactus_test_definitions/procedures/ALL-25.yaml
@@ -3,6 +3,10 @@ Category: DER
 Classes:
   - DER-A
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete

--- a/cactus_test_definitions/procedures/ALL-26.yaml
+++ b/cactus_test_definitions/procedures/ALL-26.yaml
@@ -3,6 +3,10 @@ Category: DER
 Classes:
   - DER-A
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete

--- a/cactus_test_definitions/procedures/ALL-27.yaml
+++ b/cactus_test_definitions/procedures/ALL-27.yaml
@@ -3,6 +3,10 @@ Category: DER
 Classes:
   - DER-A
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete

--- a/cactus_test_definitions/procedures/ALL-28.yaml
+++ b/cactus_test_definitions/procedures/ALL-28.yaml
@@ -3,6 +3,10 @@ Category: DER
 Classes:
   - DER-A
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -56,6 +60,9 @@ Preconditions:
         duration_seconds: 120
         opModExpLimW: 0
         opModImpLimW: 0
+  instructions:
+    - Connect a test load electrically in parallel with the DER.
+    - Set the load to consume 10% of the DER's rated active power.
 
 Steps:
   

--- a/cactus_test_definitions/procedures/ALL-29.yaml
+++ b/cactus_test_definitions/procedures/ALL-29.yaml
@@ -3,6 +3,10 @@ Category: DER
 Classes:
   - DER-A
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -12,7 +16,8 @@ Preconditions:
   checks:
     - type: end-device-contents
       parameters: {}
-
+    - type: der-settings-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:
@@ -30,6 +35,8 @@ Steps:
   
   # We will wait until the client picks up the DERControl before killing the comms
   GET-DERC:
+    instructions:
+      - Power cycle (turn off then back on again) the communications client, and while it is offline, disable the communications interface between the client and utility server (e.g. by unplugging an appropriate network cable).
     event:
       type: GET-request-received
       parameters:
@@ -50,6 +57,8 @@ Steps:
 
   # Wait for a few polls before restarting comms
   WAIT-COMMS-RESTART:
+    instructions:
+      - Re-establish communications between the client and utility server (e.g. by plugging the network cable back in).
     event:
       type: wait
       parameters:

--- a/cactus_test_definitions/procedures/BES-01.yaml
+++ b/cactus_test_definitions/procedures/BES-01.yaml
@@ -1,0 +1,125 @@
+Description: Individual readings - storage
+Category: Monitoring
+Classes:
+  - L
+
+Criteria:
+  checks:
+    - type: all-steps-complete
+      parameters: {}
+
+    # Test includes ~ 5 minutes of waiting + initial reading sent during test
+    # A minimum of 5 readings is required by the test procedure
+    - type: readings-der-stored-energy
+      parameters: { "minimum_count": 5 }
+
+Preconditions:
+  actions:
+    - type: set-comms-rate
+      parameters:
+        der_list_poll_seconds: 60
+        mup_post_seconds: 60
+
+    # Placeholder for later controls
+    - type: create-der-program
+      parameters: 
+        primacy: 1
+        fsa_id: 1
+
+Steps:
+  GET-MUP:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /mup
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - POST-MUP
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-MUP
+
+  POST-MUP:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /mup
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-MUP-2
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-MUP
+
+  GET-MUP-2:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /mup
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - WAIT-READINGS
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-MUP-2
+
+  # Wait for at least 2 readings to arrive
+  WAIT-READINGS:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 180 # Wait for at least 2 sets of readings to arrive (with post rate 60 seconds)
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-READINGS
+
+  # On this poll, client will discover new 0W control is in place
+  GET-DERC:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now)
+          duration_seconds: 600
+          opModStorageTargetW: 0
+      - type: enable-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DERC
+
+  # This just lets the test run for a few more posts after the control comes into effect
+  # after which, we will force the test to shutdown (as Criteria is partially defined by this ONLY running for a few posts)
+  WAIT-CONTROL:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 180 # Wait for at least 3 sets of readings to arrive (with post rate 60 seconds)
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL
+      - type: finish-test
+        parameters: {}

--- a/cactus_test_definitions/procedures/BES-01.yaml
+++ b/cactus_test_definitions/procedures/BES-01.yaml
@@ -3,6 +3,9 @@ Category: Monitoring
 Classes:
   - L
 
+TargetVersions:
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -14,6 +17,9 @@ Criteria:
       parameters: { "minimum_count": 5 }
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/BES-02.yaml
+++ b/cactus_test_definitions/procedures/BES-02.yaml
@@ -3,6 +3,9 @@ Category: Monitoring
 Classes:
   - L
 
+TargetVersions:
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete

--- a/cactus_test_definitions/procedures/BES-02.yaml
+++ b/cactus_test_definitions/procedures/BES-02.yaml
@@ -1,0 +1,122 @@
+Description: Capabilities and settings - storage
+Category: Monitoring
+Classes:
+  - L
+
+Criteria:
+  checks:
+    - type: all-steps-complete
+      parameters: {}
+    - type: der-capability-contents
+      parameters: {
+        "rtgMaxChargeRateW": "$(this > 0)",
+        "rtgMaxDischargeRateW": "$(this > 0)",
+        "rtgMaxWh": "$(this > 0)",
+        "vppModesSupported_set": "01",
+      }
+    - type: der-settings-contents
+      parameters: {
+        "setMaxChargeRateW": "$(this <= rtgMaxChargeRateW)",
+        "setMaxDischargeRateW": "$(this <= rtgMaxDischargeRateW)",
+        "setMaxWh": "$(this <= rtgMaxWh)",
+        "setMinWh": "$(this >= 0)",
+        "vppModesEnabled_set": "01",
+      }
+
+Steps:
+  GET-DER:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/der
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS
+            - POST-DERCAPABILITY
+            - POST-DERSETTINGS
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DER
+
+  POST-DERSTATUS:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/ders
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-2
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS
+
+  POST-DERCAPABILITY:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/dercap
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - POST-DERCAPABILITY-2
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERCAPABILITY
+
+  POST-DERSETTINGS:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/derg
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - POST-DERSETTINGS-2
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSETTINGS
+
+
+  POST-DERSTATUS-2:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/ders
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-2
+  
+  POST-DERCAPABILITY-2:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/dercap
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERCAPABILITY-2
+
+  POST-DERSETTINGS-2:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/derg
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSETTINGS-2
+

--- a/cactus_test_definitions/procedures/BES-03.yaml
+++ b/cactus_test_definitions/procedures/BES-03.yaml
@@ -1,0 +1,124 @@
+Description: Storage Control - opModStorageTargetW
+Category: Control
+Classes:
+  - L
+
+Criteria:
+  checks:
+    - type: all-steps-complete
+      parameters: {}
+
+Preconditions:
+  actions:
+    - type: set-comms-rate
+      parameters:
+        der_list_poll_seconds: 60
+        derp_list_poll_seconds: 60
+    - type: create-der-control
+      parameters:
+        start: $(now + '300 seconds')
+        duration_seconds: 900
+        opModStorageTargetW: $(rtgMaxDischargeRateW * 0.5)
+
+Steps:
+  # On this poll a new control will be discovered with opModStorageTargetW == 50% rtgMaxDischargeRateW
+  GET-DERC-1:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-END-1
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DERC-1
+
+  # Waits for the new control to finish (with a bit of overtime)
+  WAIT-CONTROL-END-1:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 1260
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-2
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-END-1
+
+  # On this poll a new control will be discovered with 0W opModStorageTargetW
+  GET-DERC-2:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now + '300 seconds')
+          duration_seconds: 900
+          opModStorageTargetW: 0
+      - type: enable-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-END-2
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DERC-2
+
+  # Waits for the new control to finish (with a bit of overtime)
+  WAIT-CONTROL-END-2:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 1260
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-3
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-END-2
+
+  # On this poll a new control will be discovered with opModStorageTargetW == -50% rtgMaxChargeRateW
+  GET-DERC-3:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now + '300 seconds')
+          duration_seconds: 900
+          opModStorageTargetW: $(0.5 * negRtgMaxChargeRateW) # Negative value
+      - type: enable-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-END-3
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DERC-3
+
+  # Waits for the new control to finish (with a bit of overtime)
+  WAIT-CONTROL-END-3:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 1260
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-END-3

--- a/cactus_test_definitions/procedures/BES-03.yaml
+++ b/cactus_test_definitions/procedures/BES-03.yaml
@@ -3,12 +3,18 @@ Category: Control
 Classes:
   - L
 
+TargetVersions:
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/BES-04.yaml
+++ b/cactus_test_definitions/procedures/BES-04.yaml
@@ -3,6 +3,9 @@ Category: Control
 Classes:
   - L
 
+TargetVersions:
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -24,6 +27,8 @@ Preconditions:
         opModStorageTargetW: $(rtgMaxDischargeRateW)
         opModExpLimW: $(2 * rtgMaxDischargeRateW)
   checks:
+    - type: end-device-contents
+      parameters: {}
     - type: der-capability-contents
       parameters: {
         "rtgMaxChargeRateW": "$(this == rtgMaxVA)",

--- a/cactus_test_definitions/procedures/BES-04.yaml
+++ b/cactus_test_definitions/procedures/BES-04.yaml
@@ -1,0 +1,218 @@
+Description: Storage control with export limits - opModStorageTargetW with opModExpLimW
+Category: Control
+Classes:
+  - L
+
+Criteria:
+  checks:
+    - type: all-steps-complete
+      parameters: {}
+
+Preconditions:
+  actions:
+    - type: set-comms-rate
+      parameters:
+        der_list_poll_seconds: 60
+        derp_list_poll_seconds: 60
+    - type: set-default-der-control
+      parameters:
+        opModExpLimW: 1500
+    - type: create-der-control
+      parameters:
+        start: $(now + '300 seconds')
+        duration_seconds: 900
+        opModStorageTargetW: $(rtgMaxDischargeRateW)
+        opModExpLimW: $(2 * rtgMaxDischargeRateW)
+  checks:
+    - type: der-capability-contents
+      parameters: {
+        "rtgMaxChargeRateW": "$(this == rtgMaxVA)",
+        "rtgMaxDischargeRateW": "$(this == rtgMaxVA)",
+      }
+    # Confirm stored energy requirement (which should contain 50% charge upon inspection) 
+    - type: readings-der-stored-energy
+      parameters: {
+        "minimum_count": 1
+      }
+
+Steps:
+  # Client discovers control for opModStorageTargetW and opModExpLimW
+  GET-DERC-1:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-END-1
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DERC-1
+  
+  # Waits for the new control to finish (with a bit of overtime)
+  WAIT-CONTROL-END-1:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 1260
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-2
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-END-1
+  
+  # Client discovers a new control for opModStorageTargetW and opModExpLimW
+  GET-DERC-2:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now + '300 seconds')
+          duration_seconds: 900
+          opModStorageTargetW: $(rtgMaxDischargeRateW)
+          opModExpLimW: $(0.5 * rtgMaxDischargeRateW)
+      - type: enable-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-END-2
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DERC-2
+
+  # Waits for the new control to finish (with a bit of overtime)
+  WAIT-CONTROL-END-2:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 1260
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-3
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-END-2
+
+  # On this poll, client will discover negative value storage target control
+  GET-DERC-3:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now + '300 seconds')
+          duration_seconds: 900
+          opModStorageTargetW: $(0 - rtgMaxChargeRateW)  # Hack to obtain negative direction control
+          opModExpLimW: $(0.5 * rtgMaxDischargeRateW)
+      - type: enable-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-END-3
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DERC-3
+
+  # Waits for the new control to finish (with a bit of overtime)
+  WAIT-CONTROL-END-3:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 1260
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-4
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-END-3
+
+  # On this poll, client will discover zero value storage target control
+  GET-DERC-4:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now + '300 seconds')
+          duration_seconds: 900
+          opModStorageTargetW: 0
+          opModExpLimW: 0
+      - type: enable-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-END-4
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DERC-4
+
+  # Waits for the new control to finish (with a bit of overtime)
+  WAIT-CONTROL-END-4:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 1260
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-5
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-END-4
+
+  # On this poll, client will discover negative storage target control
+  GET-DERC-5:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now + '300 seconds')
+          duration_seconds: 900
+          opModStorageTargetW: $(0.3 * rtgMaxDischargeRateW)
+          opModExpLimW: $(rtgMaxDischargeRateW)
+      - type: enable-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-END-5
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DERC-5
+    
+  # Waits for the new control to finish (with a bit of overtime)
+  WAIT-CONTROL-END-5:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 1260
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-END-5
+

--- a/cactus_test_definitions/procedures/DRA-01.yaml
+++ b/cactus_test_definitions/procedures/DRA-01.yaml
@@ -1,0 +1,52 @@
+Description: Configuration
+Category: Demand Response
+Classes:
+  - DR-A
+
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
+
+Criteria:
+  checks:
+    - type: all-steps-complete
+      parameters: {}
+    - type: end-device-contents
+      parameters:
+        deviceCategory_anyset: '20098' # any of bits 3, 4, 7 and 17 being set (for the device type)
+    - type: der-capability-contents
+      parameters: 
+        modesSupported_set: '80' # bit 7 is set - opModFixedW. 
+      
+
+Steps:
+
+  # The test will "start" once the DER list is fetched (signalling the end of ALL-01/ALL-02 discovery)
+  GET-DER:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/der
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - POST-DER-CAPABILITY
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DER
+
+  POST-DER-CAPABILITY:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/dercap
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DER-CAPABILITY
+
+  

--- a/cactus_test_definitions/procedures/DRA-02.yaml
+++ b/cactus_test_definitions/procedures/DRA-02.yaml
@@ -1,0 +1,64 @@
+Description: Disconnect Instruction
+Category: Demand Response
+Classes:
+  - DR-L
+  - DR-G
+
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
+Criteria:
+  checks:
+    - type: all-steps-complete
+      parameters: {}
+
+Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
+    - type: der-settings-contents
+      parameters: {}
+  instructions:
+    - The controlled device is connected to the grid and consuming/generating power of at least 50% of its nameplate rating
+      
+Steps:
+
+  # (a)
+  GET-DERC:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now)
+          duration_seconds: 60
+          opModConnect: false
+      - type: enable-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DERC
+
+  # (b)
+  POST-DERSTATUS:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/ders
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-status-contents
+      parameters:
+        alarmStatus: 0
+        operationalModeStatus: 100
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS

--- a/cactus_test_definitions/procedures/DRD-01.yaml
+++ b/cactus_test_definitions/procedures/DRD-01.yaml
@@ -1,0 +1,667 @@
+Description: DRED operational instruction response
+Category: Demand Response
+Classes:
+  - DR-D
+
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
+Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
+    - type: der-settings-contents
+      parameters: {}
+  actions:
+    - type: set-comms-rate
+      parameters:
+        der_list_poll_seconds: 60
+        derp_list_poll_seconds: 60
+
+Criteria:
+  checks:
+    - type: all-steps-complete
+      parameters: {}
+    
+Steps:
+
+  # (a, b) - Created DERControl with immediate start 
+  GET-DERC-1:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now)
+          duration_seconds: 60
+          opModConnect: false
+      - type: enable-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-1
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DERC-1
+
+  # (c) Wait for the update to DERStatus
+  POST-DERSTATUS-1:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/ders
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-status-contents
+      parameters:
+        alarmStatus: 0
+        operationalModeStatus: 100
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-2
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-1
+      
+  # (d, e, f) Create DERControl with immediate start to reconnect and then a second DERControl
+  GET-DERC-2:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now)
+          duration_seconds: 60
+          opModConnect: true
+      - type: create-der-control
+        parameters:
+          start: $(now + '120 seconds')
+          duration_seconds: 60
+          opModFixedW: -75
+      - type: enable-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-2
+            - POST-DERSETTINGS-2
+            - WAIT-DERC-2
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DERC-2
+  
+  # (g, h)
+  POST-DERSTATUS-2:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/ders
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-status-contents
+      parameters:
+        alarmStatus: 0
+        operationalModeStatus: 103
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-2
+
+  # (g, h)
+  POST-DERSETTINGS-2:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/ders
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-settings-contents
+      parameters:
+        modesEnabled: 80 # bit 7
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSETTINGS-2
+
+  # (i) After the end of the previous control...
+  WAIT-DERC-2:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120 # Wait for DERControls to fully complete
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-3
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-DERC-2
+
+  # (i, j) ... The server will create a DERControl
+  GET-DERC-3:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now + '60 seconds')
+          duration_seconds: 60
+          opModFixedW: -50
+      - type: enable-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-3
+            - POST-DERSETTINGS-3
+            - WAIT-DERC-3
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DERC-3
+
+  # (k)
+  POST-DERSTATUS-3:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/ders
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-status-contents
+      parameters:
+        alarmStatus: 0
+        operationalModeStatus: 102
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-3
+
+  # (k)
+  POST-DERSETTINGS-3:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/derg
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-settings-contents
+      parameters:
+        modesEnabled: 80 # bit 7
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSETTINGS-3
+
+
+  # (l) After the end of the previous control...
+  WAIT-DERC-3:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120 # Wait for DERControls to fully complete
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-4
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-DERC-3
+
+  # (l) ... create a new DERControl
+  GET-DERC-4:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now + '60 seconds')
+          duration_seconds: 60
+          opModFixedW: -0.01
+      - type: enable-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-4
+            - POST-DERSETTINGS-4
+            - WAIT-DERC-4
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DERC-4
+
+
+  # (m, n)
+  POST-DERSTATUS-4:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/ders
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-status-contents
+      parameters:
+        alarmStatus: 0
+        operationalModeStatus: 101
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-4
+
+  # (m, n)
+  POST-DERSETTINGS-4:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/derg
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-settings-contents
+      parameters:
+        modesEnabled: 80 # bit 7
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSETTINGS-4
+
+  # (o) After the end of the previous control...
+  WAIT-DERC-4:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120 # Wait for DERControls to fully complete
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-5
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-DERC-4
+
+
+  # (o) ... create a new DERControl
+  GET-DERC-5:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now + '60 seconds')
+          duration_seconds: 60
+          opModFixedW: -100
+      - type: enable-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-5
+            - POST-DERSETTINGS-5
+            - WAIT-DERC-5
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DERC-5
+
+  # (p, q)
+  POST-DERSTATUS-5:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/ders
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-status-contents
+      parameters:
+        alarmStatus: 0
+        operationalModeStatus: 104
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-5
+
+  # (p, q)
+  POST-DERSETTINGS-5:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/derg
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-settings-contents
+      parameters:
+        modesEnabled: 80 # bit 7
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSETTINGS-5
+
+  # (r) After the end of the previous control...
+  WAIT-DERC-5:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120 # Wait for DERControls to fully complete
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-6
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-DERC-5
+
+  # (r) ... create a new DERControl
+  GET-DERC-6:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now + '60 seconds')
+          duration_seconds: 60
+          opModFixedW: 75
+      - type: enable-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-6
+            - POST-DERSETTINGS-6
+            - WAIT-DERC-6
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DERC-6
+
+  # (s, t)
+  POST-DERSTATUS-6:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/ders
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-status-contents
+      parameters:
+        alarmStatus: 0
+        operationalModeStatus: 107
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-6
+
+  # (s, t)
+  POST-DERSETTINGS-6:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/derg
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-settings-contents
+      parameters:
+        modesEnabled: 80 # bit 7
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSETTINGS-6
+
+  # (u) After the end of the previous control...
+  WAIT-DERC-6:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120 # Wait for DERControls to fully complete
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-7
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-DERC-6
+
+  # (u) ... create a new DERControl
+  GET-DERC-7:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now + '60 seconds')
+          duration_seconds: 60
+          opModFixedW: 50
+      - type: enable-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-7
+            - POST-DERSETTINGS-7
+            - WAIT-DERC-7
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DERC-7
+
+  # (v, w)
+  POST-DERSTATUS-7:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/ders
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-status-contents
+      parameters:
+        alarmStatus: 0
+        operationalModeStatus: 107
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-7
+
+  # (v, w)
+  POST-DERSETTINGS-7:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/derg
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-settings-contents
+      parameters:
+        modesEnabled: 80 # bit 7
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSETTINGS-7
+
+  # (x) After the end of the previous control...
+  WAIT-DERC-7:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120 # Wait for DERControls to fully complete
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-8
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-DERC-7
+
+  # (x) ... create a new DERControl
+  GET-DERC-8:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now + '60 seconds')
+          duration_seconds: 60
+          opModFixedW: 0
+      - type: enable-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-8
+            - POST-DERSETTINGS-8
+            - WAIT-DERC-8
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DERC-8
+
+  # (y, z)
+  POST-DERSTATUS-8:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/ders
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-status-contents
+      parameters:
+        alarmStatus: 0
+        operationalModeStatus: 105
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-8
+
+  # (y, z)
+  POST-DERSETTINGS-8:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/derg
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-settings-contents
+      parameters:
+        modesEnabled: 80 # bit 7
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSETTINGS-8
+
+  # (aa) After the end of the previous control...
+  WAIT-DERC-8:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120 # Wait for DERControls to fully complete
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-9
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-DERC-8
+
+  # (aa) ... create a new DERControl
+  GET-DERC-9:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now + '60 seconds')
+          duration_seconds: 60
+          opModFixedW: 100
+      - type: enable-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-9
+            - POST-DERSETTINGS-9
+            - WAIT-DERC-9
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DERC-9
+
+  # (bb, cc)
+  POST-DERSTATUS-9:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/ders
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-status-contents
+      parameters:
+        alarmStatus: 0
+        operationalModeStatus: 108
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-9
+
+  # (bb, cc)
+  POST-DERSETTINGS-9:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/derg
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-settings-contents
+      parameters:
+        modesEnabled: 80 # bit 7
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSETTINGS-9
+  
+  WAIT-DERC-9:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120 # Wait for DERControls to fully complete
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-DERC-9
+      - type: finish-test
+        parameters: {}

--- a/cactus_test_definitions/procedures/DRL-01.yaml
+++ b/cactus_test_definitions/procedures/DRL-01.yaml
@@ -1,0 +1,327 @@
+Description: Load operational instructions
+Category: Demand Response
+Classes:
+  - DR-L
+
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
+Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
+    - type: der-settings-contents
+      parameters: {}
+  actions:
+    - type: set-comms-rate
+      parameters:
+        der_list_poll_seconds: 60
+        derp_list_poll_seconds: 60
+  instructions:
+    - The controlled device should be connected to the grid and consuming 90% (+/- 5%) of its nameplate rating maximum.
+
+Criteria:
+  checks:
+    - type: all-steps-complete
+      parameters: {}
+    
+Steps:
+
+  # (a, b)
+  GET-DERC-1:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now + '60 seconds')
+          duration_seconds: 60
+          opModFixedW: -75
+      - type: enable-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-1
+            - POST-DERSETTINGS-1
+            - WAIT-DERC-1
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DERC-1
+
+  # (c)
+  POST-DERSTATUS-1:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/ders
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-status-contents
+      parameters:
+        alarmStatus: 0
+        operationalModeStatus: 103
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-1
+
+  # (c)
+  POST-DERSETTINGS-1:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/derg
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-settings-contents
+      parameters:
+        modesEnabled: 80 # bit 7
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSETTINGS-1
+
+
+  # (d) After the end of the previous control...
+  WAIT-DERC-1:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120 # Wait for DERControls to fully complete
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-2
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-DERC-1
+
+  # (d) ... create a new DERControl
+  GET-DERC-2:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now + '60 seconds')
+          duration_seconds: 60
+          opModFixedW: -50
+      - type: enable-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-2
+            - POST-DERSETTINGS-2
+            - WAIT-DERC-2
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DERC-2
+
+
+  # (e, f)
+  POST-DERSTATUS-2:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/ders
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-status-contents
+      parameters:
+        alarmStatus: 0
+        operationalModeStatus: 102
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-2
+
+  # (e, f)
+  POST-DERSETTINGS-2:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/derg
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-settings-contents
+      parameters:
+        modesEnabled: 80 # bit 7
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSETTINGS-2
+
+  # (g) After the end of the previous control...
+  WAIT-DERC-2:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120 # Wait for DERControls to fully complete
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-3
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-DERC-2
+
+
+  # (g) ... create a new DERControl
+  GET-DERC-3:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now + '60 seconds')
+          duration_seconds: 60
+          opModFixedW: -0.01
+      - type: enable-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-3
+            - POST-DERSETTINGS-3
+            - WAIT-DERC-3
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DERC-3
+
+  # (h, i)
+  POST-DERSTATUS-3:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/ders
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-status-contents
+      parameters:
+        alarmStatus: 0
+        operationalModeStatus: 101
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-3
+
+  # (h, i)
+  POST-DERSETTINGS-3:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/derg
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-settings-contents
+      parameters:
+        modesEnabled: 80 # bit 7
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSETTINGS-3
+
+  # (j) After the end of the previous control...
+  WAIT-DERC-3:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120 # Wait for DERControls to fully complete
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-4
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-DERC-3
+
+  # (j) ... create a new DERControl
+  GET-DERC-4:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now + '60 seconds')
+          duration_seconds: 60
+          opModFixedW: -100
+      - type: enable-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-4
+            - POST-DERSETTINGS-4
+            - WAIT-DERC-4
+      - type: remove-steps
+        parameters:
+          steps:
+            - GET-DERC-4
+
+  # (k, l)
+  POST-DERSTATUS-4:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/ders
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-status-contents
+      parameters:
+        alarmStatus: 0
+        operationalModeStatus: 104
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSTATUS-4
+
+  # (k, l)
+  POST-DERSETTINGS-4:
+    event:
+      type: POST-request-received
+      parameters:
+        endpoint: /edev/1/der/1/derg
+        serve_request_first: true # Run this AFTER server receives the request
+    checks:
+      type: der-settings-contents
+      parameters:
+        modesEnabled: 80 # bit 7
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - POST-DERSETTINGS-4
+
+  # Wait for the controls to finish
+  WAIT-DERC-4:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120 # Wait for DERControls to fully complete
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-DERC-4
+      - type: finish-test
+        parameters: {}
+

--- a/cactus_test_definitions/procedures/GEN-01.yaml
+++ b/cactus_test_definitions/procedures/GEN-01.yaml
@@ -3,12 +3,19 @@ Category: Control
 Classes:
   - G
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/GEN-02.yaml
+++ b/cactus_test_definitions/procedures/GEN-02.yaml
@@ -3,12 +3,19 @@ Category: Control
 Classes:
   - G
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/GEN-03.yaml
+++ b/cactus_test_definitions/procedures/GEN-03.yaml
@@ -3,12 +3,21 @@ Category: Control
 Classes:
   - G
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
+    - type: der-settings-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/GEN-04.yaml
+++ b/cactus_test_definitions/procedures/GEN-04.yaml
@@ -3,12 +3,21 @@ Category: Control
 Classes:
   - G
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
+    - type: der-settings-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/GEN-05.yaml
+++ b/cactus_test_definitions/procedures/GEN-05.yaml
@@ -4,6 +4,10 @@ Classes:
   - G
   - S
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -12,9 +16,12 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+    - type: der-settings-contents
+      parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         # Set this to a large value - we want to test they respond due to notification - not polling

--- a/cactus_test_definitions/procedures/GEN-06.yaml
+++ b/cactus_test_definitions/procedures/GEN-06.yaml
@@ -4,6 +4,10 @@ Classes:
   - G
   - S
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -12,9 +16,12 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+    - type: der-settings-contents
+      parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         # Set this to a large value - we want to test they respond due to notification - not polling

--- a/cactus_test_definitions/procedures/GEN-07.yaml
+++ b/cactus_test_definitions/procedures/GEN-07.yaml
@@ -4,6 +4,10 @@ Classes:
   - G
   - S
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -12,9 +16,12 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+    - type: der-settings-contents
+      parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         # Set this to a large value - we want to test they respond due to notification - not polling

--- a/cactus_test_definitions/procedures/GEN-08.yaml
+++ b/cactus_test_definitions/procedures/GEN-08.yaml
@@ -4,6 +4,10 @@ Classes:
   - G
   - S
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -12,9 +16,12 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+    - type: der-settings-contents
+      parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         # Set this to a large value - we want to test they respond due to notification - not polling

--- a/cactus_test_definitions/procedures/GEN-09.yaml
+++ b/cactus_test_definitions/procedures/GEN-09.yaml
@@ -3,6 +3,10 @@ Category: DER
 Classes:
   - DER-G
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete

--- a/cactus_test_definitions/procedures/GEN-10.yaml
+++ b/cactus_test_definitions/procedures/GEN-10.yaml
@@ -3,6 +3,10 @@ Category: DER
 Classes:
   - DER-G
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete

--- a/cactus_test_definitions/procedures/GEN-11.yaml
+++ b/cactus_test_definitions/procedures/GEN-11.yaml
@@ -3,6 +3,10 @@ Category: DER
 Classes:
   - DER-G
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete

--- a/cactus_test_definitions/procedures/GEN-12.yaml
+++ b/cactus_test_definitions/procedures/GEN-12.yaml
@@ -3,6 +3,10 @@ Category: DER
 Classes:
   - DER-G
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete

--- a/cactus_test_definitions/procedures/GEN-13.yaml
+++ b/cactus_test_definitions/procedures/GEN-13.yaml
@@ -3,6 +3,10 @@ Category: DER
 Classes:
   - DER-G
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -12,7 +16,8 @@ Preconditions:
   checks:
     - type: end-device-contents
       parameters: {}
-
+    - type: der-settings-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:
@@ -29,17 +34,25 @@ Preconditions:
         start: $(now + '1 minute')
         duration_seconds: 420
         opModExpLimW: $(setMaxW * 0.2)
+  instructions:
+    - Connect a test load electrically in parallel with the DER.
+    - Set the load to consume 0W.
 
 Steps:
 
   # This test is purely following a sequence of DERControls. It's expected that the following events occurs out of band:
   # at t=0 - Test load is consuming 0W
-  # at t=120s - Test load is consuming 10% of setMaxW
-  # at t=300s - Test load is consuming 0W
+  # at t=120s - Test load is consuming 20% of setMaxW
+  # at t=240s - Test load is consuming 10% of setMaxW
+  # at t=360s - Test load is consuming 0W
   #
   # Validation MUST be performed by power meter to ensure that the DER is adjusting its power in response to changing 
   # loads
   WAIT-TEST-END:
+    instructions:
+      - At t=120s, set the load to consume 20% of the DER's rated active power.
+      - At t=240s, set the load to consume 10% of the DER's rated active power.
+      - At t=360s, set the load to consume 0W.
     event:
       type: wait
       parameters:

--- a/cactus_test_definitions/procedures/LOA-01.yaml
+++ b/cactus_test_definitions/procedures/LOA-01.yaml
@@ -3,12 +3,19 @@ Category: Control
 Classes:
   - L
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/LOA-02.yaml
+++ b/cactus_test_definitions/procedures/LOA-02.yaml
@@ -3,12 +3,19 @@ Category: Control
 Classes:
   - L
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/LOA-03.yaml
+++ b/cactus_test_definitions/procedures/LOA-03.yaml
@@ -3,12 +3,21 @@ Category: Control
 Classes:
   - L
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
+    - type: der-settings-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/LOA-04.yaml
+++ b/cactus_test_definitions/procedures/LOA-04.yaml
@@ -3,12 +3,21 @@ Category: Control
 Classes:
   - L
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
       parameters: {}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
+    - type: der-settings-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/procedures/LOA-05.yaml
+++ b/cactus_test_definitions/procedures/LOA-05.yaml
@@ -4,6 +4,10 @@ Classes:
   - L
   - S
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -12,9 +16,12 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+    - type: der-settings-contents
+      parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         # Set this to a large value - we want to test they respond due to notification - not polling

--- a/cactus_test_definitions/procedures/LOA-06.yaml
+++ b/cactus_test_definitions/procedures/LOA-06.yaml
@@ -4,6 +4,10 @@ Classes:
   - L
   - S
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -12,9 +16,12 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+    - type: der-settings-contents
+      parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         # Set this to a large value - we want to test they respond due to notification - not polling

--- a/cactus_test_definitions/procedures/LOA-07.yaml
+++ b/cactus_test_definitions/procedures/LOA-07.yaml
@@ -4,6 +4,10 @@ Classes:
   - L
   - S
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -12,9 +16,12 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+    - type: der-settings-contents
+      parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         # Set this to a large value - we want to test they respond due to notification - not polling

--- a/cactus_test_definitions/procedures/LOA-08.yaml
+++ b/cactus_test_definitions/procedures/LOA-08.yaml
@@ -4,6 +4,10 @@ Classes:
   - L
   - S
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -12,9 +16,12 @@ Criteria:
       parameters: {}
 
 Preconditions:
-  actions:
-    - type: register-end-device
+  checks:
+    - type: end-device-contents
       parameters: {}
+    - type: der-settings-contents
+      parameters: {}
+  actions:
     - type: set-comms-rate
       parameters:
         # Set this to a large value - we want to test they respond due to notification - not polling

--- a/cactus_test_definitions/procedures/LOA-09.yaml
+++ b/cactus_test_definitions/procedures/LOA-09.yaml
@@ -3,6 +3,10 @@ Category: DER
 Classes:
   - DER-L
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete

--- a/cactus_test_definitions/procedures/LOA-10.yaml
+++ b/cactus_test_definitions/procedures/LOA-10.yaml
@@ -3,6 +3,10 @@ Category: DER
 Classes:
   - DER-L
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete

--- a/cactus_test_definitions/procedures/LOA-11.yaml
+++ b/cactus_test_definitions/procedures/LOA-11.yaml
@@ -3,6 +3,10 @@ Category: DER
 Classes:
   - DER-L
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete

--- a/cactus_test_definitions/procedures/LOA-12.yaml
+++ b/cactus_test_definitions/procedures/LOA-12.yaml
@@ -3,6 +3,10 @@ Category: DER
 Classes:
   - DER-L
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete

--- a/cactus_test_definitions/procedures/LOA-13.yaml
+++ b/cactus_test_definitions/procedures/LOA-13.yaml
@@ -3,6 +3,10 @@ Category: DER
 Classes:
   - DER-L
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -12,7 +16,8 @@ Preconditions:
   checks:
     - type: end-device-contents
       parameters: {}
-
+    - type: der-settings-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:
@@ -23,23 +28,31 @@ Preconditions:
       parameters:
         start: $(now)
         duration_seconds: 60
-        opModExpLimW: $(setMaxW * 2)
+        opModImpLimW: $(setMaxW * 2)
     - type: create-der-control
       parameters:
         start: $(now + '1 minute')
         duration_seconds: 420
-        opModExpLimW: $(setMaxW * 0.2)
+        opModImpLimW: $(setMaxW * 0.2)
+  instructions:
+    - Connect a test load electrically in parallel with the DER.
+    - Set the load to consume 0W.
 
 Steps:
 
   # This test is purely following a sequence of DERControls. It's expected that the following events occurs out of band:
   # at t=0 - Test load is consuming 0W
-  # at t=120s - Test load is consuming 10% of setMaxW
-  # at t=300s - Test load is consuming 0W
+  # at t=120s - Test load is consuming 20% of setMaxW
+  # at t=240s - Test load is consuming 10% of setMaxW
+  # at t=360s - Test load is consuming 0W
   #
   # Validation MUST be performed by power meter to ensure that the DER is adjusting its power in response to changing 
   # loads
   WAIT-TEST-END:
+    instructions:
+      - At t=120s, set the load to consume 20% of the DER's rated active power.
+      - At t=240s, set the load to consume 10% of the DER's rated active power.
+      - At t=360s, set the load to consume 0W.
     event:
       type: wait
       parameters:

--- a/cactus_test_definitions/procedures/MUL-01.yaml
+++ b/cactus_test_definitions/procedures/MUL-01.yaml
@@ -3,6 +3,10 @@ Category: Monitoring
 Classes:
   - M
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -11,6 +15,10 @@ Criteria:
 
 Preconditions:
   checks:
+    - type: end-device-contents
+      parameters: {}
+    - type: der-settings-contents
+      parameters: {}
     - type: der-status-contents
       parameters: 
         genConnectStatus_bit0: true
@@ -26,6 +34,8 @@ Steps:
   
   # The client powers off one DER
   POST-DERSTATUS-FIRST-DISCONNECT:
+    instructions:
+      - Power off one DER either by a hardware switch on the DER or by disconnection from the grid supply. Priority should be given to DER capable of generation.
     event:
       type: POST-request-received
       parameters:
@@ -51,6 +61,8 @@ Steps:
   
   # The client powers off all remaining DER
   POST-DERSTATUS-FULL-DISCONNECT:
+    instructions:
+      - Power off off remaining DER.
     event:
       type: POST-request-received
       parameters:

--- a/cactus_test_definitions/procedures/MUL-02.yaml
+++ b/cactus_test_definitions/procedures/MUL-02.yaml
@@ -3,6 +3,10 @@ Category: Monitoring
 Classes:
   - M
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -23,6 +27,11 @@ Criteria:
       parameters: {"minimum_count": 3}
 
 Preconditions:
+  checks:
+    - type: end-device-contents
+      parameters: {}
+    - type: der-settings-contents
+      parameters: {}
   actions:
     - type: set-comms-rate
       parameters:
@@ -40,6 +49,9 @@ Preconditions:
         duration_seconds: 120
         opModExpLimW: 0
         opModImpLimW: 0
+  instructions:
+    - Connect a test load electrically in parallel with the DER.
+    - Set the load to consume 10% of the sum total of the DERs' rated active power.
 
 Steps:
 

--- a/cactus_test_definitions/procedures/MUL-03.yaml
+++ b/cactus_test_definitions/procedures/MUL-03.yaml
@@ -2,7 +2,11 @@ Description: Validate DERCapability and DERSettings For Multiple DER
 Category: Monitoring
 Classes:
   - M
-  
+
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -12,6 +16,11 @@ Criteria:
     - type: der-settings-contents
       parameters: {}
     - type: der-status-contents
+      parameters: {}
+
+Preconditions:
+  checks:
+    - type: end-device-contents
       parameters: {}
 
 Steps:
@@ -34,6 +43,8 @@ Steps:
   # There is little we can automatically validate - this test will rely on the lab technician to validate the 
   # DERSettings being reported in the output report
   POST-DERSETTINGS-UPDATED:
+    instructions:
+      - Modify the maximum rating of one DER in the device settings.
     event:
       type: POST-request-received
       parameters:

--- a/cactus_test_definitions/procedures/OPT-1-IN-BAND.yaml
+++ b/cactus_test_definitions/procedures/OPT-1-IN-BAND.yaml
@@ -3,6 +3,10 @@ Category: Registration
 Classes:
   - C
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Criteria:
   checks:
     - type: all-steps-complete
@@ -70,7 +74,7 @@ Steps:
         parameters:
           steps:
             - GET-DER
-            - POST-CP
+            - PUT-CP
       - type: remove-steps
         parameters:
           steps:
@@ -87,13 +91,13 @@ Steps:
           steps:
             - GET-DER
 
-  POST-CP:
+  PUT-CP:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/cp
     actions:
       - type: remove-steps
         parameters:
           steps:
-            - POST-CP
+            - PUT-CP

--- a/cactus_test_definitions/procedures/OPT-1-OUT-OF-BAND.yaml
+++ b/cactus_test_definitions/procedures/OPT-1-OUT-OF-BAND.yaml
@@ -3,6 +3,10 @@ Category: Registration
 Classes:
   - C
 
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+
 Preconditions:
   actions:
     - type: register-end-device
@@ -30,7 +34,7 @@ Steps:
             - GET-EDEV-LIST
             - GET-TM
             - GET-DER
-            - POST-CP
+            - PUT-CP
       - type: remove-steps
         parameters:
           steps:
@@ -69,13 +73,13 @@ Steps:
           steps:
             - GET-DER
 
-  POST-CP:
+  PUT-CP:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/cp
     actions:
       - type: remove-steps
         parameters:
           steps:
-            - POST-CP
+            - PUT-CP

--- a/cactus_test_definitions/procedures/test-procedures.yaml
+++ b/cactus_test_definitions/procedures/test-procedures.yaml
@@ -61,4 +61,8 @@ TestProcedures:
   MUL-03: !include MUL-03.yaml
   OPT-1-IN-BAND: !include OPT-1-IN-BAND.yaml
   OPT-1-OUT-OF-BAND: !include OPT-1-OUT-OF-BAND.yaml
+  BES-01: !include BES-01.yaml
+  BES-02: !include BES-02.yaml
+  BES-03: !include BES-03.yaml
+  BES-04: !include BES-04.yaml
 

--- a/cactus_test_definitions/procedures/test-procedures.yaml
+++ b/cactus_test_definitions/procedures/test-procedures.yaml
@@ -30,6 +30,10 @@ TestProcedures:
   ALL-27: !include ALL-27.yaml
   ALL-28: !include ALL-28.yaml
   ALL-29: !include ALL-29.yaml
+  DRA-01: !include DRA-01.yaml
+  DRA-02: !include DRA-02.yaml
+  DRD-01: !include DRD-01.yaml
+  DRL-01: !include DRL-01.yaml
   GEN-01: !include GEN-01.yaml
   GEN-02: !include GEN-02.yaml
   GEN-03: !include GEN-03.yaml

--- a/cactus_test_definitions/test_procedures.py
+++ b/cactus_test_definitions/test_procedures.py
@@ -79,6 +79,12 @@ class TestProcedureId(StrEnum):
     OPT_1_IN_BAND = "OPT-1-IN-BAND"
     OPT_1_OUT_OF_BAND = "OPT-1-OUT-OF-BAND"
 
+    # Storage extension
+    BES_01 = "BES-01"
+    BES_02 = "BES-02"
+    BES_03 = "BES-03"
+    BES_04 = "BES-04"
+
 
 class UniqueKeyLoader(yaml.SafeLoader):
     """Originally sourced from https://gist.github.com/pypt/94d747fe5180851196eb

--- a/cactus_test_definitions/test_procedures.py
+++ b/cactus_test_definitions/test_procedures.py
@@ -13,6 +13,14 @@ from cactus_test_definitions.events import Event, validate_event_parameters
 from dataclass_wizard import YAMLWizard
 
 
+class CSIPAusVersion(StrEnum):
+    """The various version identifiers for CSIP-Aus. Used for distinguishing what tests are compatible with what
+    released versions CSIP-Aus."""
+
+    RELEASE_1_2 = "v1.2"
+    BETA_1_3_STORAGE = "v1.3-beta/storage"
+
+
 class TestProcedureId(StrEnum):
     """The set of all available test ID's
 
@@ -47,6 +55,10 @@ class TestProcedureId(StrEnum):
     ALL_27 = "ALL-27"
     ALL_28 = "ALL-28"
     ALL_29 = "ALL-29"
+    DRA_01 = "DRA-01"
+    DRA_02 = "DRA-02"
+    DRD_01 = "DRD-01"
+    DRL_01 = "DRL-01"
     GEN_01 = "GEN-01"
     GEN_02 = "GEN-02"
     GEN_03 = "GEN-03"
@@ -112,10 +124,15 @@ class Step:
     """A step is a part of the test procedure that waits for some form of event before running a set of actions.
 
     It's common for a step to activate other "steps" so that the state of the active test procedure can "evolve" in
-    response to client behaviour"""
+    response to client behaviour
+
+    Instructions are out-of-band operations that need performing during the step
+    e.g. disconnect DER from grid, disable power consumption etc.
+    """
 
     event: Event  # The event to act as a trigger
     actions: list[Action]  # The actions to execute when the trigger is met
+    instructions: list[str] | None = None
 
 
 @dataclass
@@ -123,10 +140,15 @@ class Preconditions:
     """Preconditions are run during the "initialization" state that precedes the start of a test. They typically
     allow for the setup of the test.
 
-    Checks are also included to prevent a client from starting a test before they have correctly met preconditions"""
+    Checks are also included to prevent a client from starting a test before they have correctly met preconditions
+
+    Instructions are out-of-band operations that need performing at the start of the test procedure
+    e.g. attach a load etc.
+    """
 
     actions: list[Action] | None = None  # To be executed as the test case first "starts"
     checks: list[Check] | None = None  # Will prevent move from "init" state to "started" state of a test if any fail
+    instructions: list[str] | None = None
 
 
 @dataclass
@@ -145,6 +167,7 @@ class TestProcedure:
     description: str  # Metadata from test definitions
     category: str  # Metadata from test definitions
     classes: list[str]  # Metadata from test definitions
+    target_versions: list[CSIPAusVersion]  # What version(s) of csip-aus is this test targeting?
     steps: dict[str, Step]
     preconditions: Preconditions | None = None  # These execute during "init" and setup the test for a valid start state
     criteria: Criteria | None = None  # How will success/failure of this procedure be determined?

--- a/cactus_test_definitions/variable_expressions.py
+++ b/cactus_test_definitions/variable_expressions.py
@@ -58,8 +58,6 @@ class NamedVariableType(IntEnum):
     DERSETTING_SET_MAX_CHARGE_RATE_W = auto()
     DERSETTING_SET_MAX_DISCHARGE_RATE_W = auto()
     DERSETTING_SET_MAX_WH = auto()
-    # Storage extension
-    DERSETTING_SET_MIN_WH = auto()
 
     # Must resolve to DERCapablity of the current EndDevice under test
     DERCAPABILITY_RTG_MAX_VA = auto()  # VA ( after multiplier applied), reference $rtgMaxVA
@@ -68,6 +66,10 @@ class NamedVariableType(IntEnum):
     DERCAPABILITY_RTG_MAX_CHARGE_RATE_W = auto()  # W ( after multiiplier applied), reference $rtgMaxChargeRateW
     DERCAPABILITY_RTG_MAX_DISCHARGE_RATE_W = auto()  # W ( after multiplier applied), reference $rtgMaxDischargeRateW
     DERCAPABILITY_RTG_MAX_WH = auto()  # Wh ( after multiplier applied), reference $rtgMaxWh
+
+    # Storage extension
+    DERSETTING_SET_MIN_WH = auto()
+    DERCAPABILITY_NEG_RTG_MAX_CHARGE_RATE_W = auto()  # -W (after multiplier applied), reference $negRtgMaxChargeRateW
 
 
 class OperationType(IntEnum):
@@ -203,6 +205,8 @@ def parse_unary_expression(token: Token) -> Constant | NamedVariable:
             # Storage extension
             case "setMinWh":
                 return NamedVariable(NamedVariableType.DERSETTING_SET_MIN_WH)
+            case "negRtgMaxChargeRateW":
+                return NamedVariable(NamedVariableType.DERCAPABILITY_NEG_RTG_MAX_CHARGE_RATE_W)
 
         raise UnparseableVariableExpressionError(f"'{token.string}' isn't recognized as a named variable")
 

--- a/cactus_test_definitions/variable_expressions.py
+++ b/cactus_test_definitions/variable_expressions.py
@@ -58,6 +58,8 @@ class NamedVariableType(IntEnum):
     DERSETTING_SET_MAX_CHARGE_RATE_W = auto()
     DERSETTING_SET_MAX_DISCHARGE_RATE_W = auto()
     DERSETTING_SET_MAX_WH = auto()
+    # Storage extension
+    DERSETTING_SET_MIN_WH = auto()
 
     # Must resolve to DERCapablity of the current EndDevice under test
     DERCAPABILITY_RTG_MAX_VA = auto()  # VA ( after multiplier applied), reference $rtgMaxVA
@@ -198,6 +200,9 @@ def parse_unary_expression(token: Token) -> Constant | NamedVariable:
                 return NamedVariable(NamedVariableType.DERCAPABILITY_RTG_MAX_DISCHARGE_RATE_W)
             case "rtgMaxWh":
                 return NamedVariable(NamedVariableType.DERCAPABILITY_RTG_MAX_WH)
+            # Storage extension
+            case "setMinWh":
+                return NamedVariable(NamedVariableType.DERSETTING_SET_MIN_WH)
 
         raise UnparseableVariableExpressionError(f"'{token.string}' isn't recognized as a named variable")
 

--- a/cactus_test_definitions/variable_expressions.py
+++ b/cactus_test_definitions/variable_expressions.py
@@ -1,9 +1,9 @@
+import tokenize
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import IntEnum, auto
 from io import StringIO
 from re import match, search
-import tokenize
 from typing import Any
 
 from cactus_test_definitions.errors import UnparseableVariableExpressionError
@@ -339,3 +339,24 @@ def try_extract_variable_expression(body: Any) -> str | None:
 def is_resolvable_variable(v: Any) -> bool:
     """Returns True if the supplied value is a variable definition that requires resolving"""
     return isinstance(v, NamedVariable) or isinstance(v, Expression) or isinstance(v, Constant)
+
+
+def has_named_variable(
+    parameter_value: NamedVariable | Expression | Constant, named_variable: NamedVariableType
+) -> bool:
+    """Return True if the supplied named variable is used in the the parameter 'parameter_value'"""
+
+    if isinstance(parameter_value, Constant):
+        return False
+
+    if isinstance(parameter_value, NamedVariable):
+        return parameter_value.variable == named_variable
+
+    if isinstance(parameter_value, Expression):
+        if isinstance(parameter_value.lhs_operand, NamedVariable):
+            if parameter_value.lhs_operand.variable == named_variable:
+                return True
+        if isinstance(parameter_value.rhs_operand, NamedVariable):
+            if parameter_value.rhs_operand.variable == named_variable:
+                return True
+        return False

--- a/tests/data/config_action_parameters.yaml
+++ b/tests/data/config_action_parameters.yaml
@@ -7,6 +7,8 @@ TestProcedures:
     Category: Test
     Classes:
       - A
+    TargetVersions:
+      - v1.2
     Steps:
       Step-1:
         listener-enabled: true

--- a/tests/data/config_with_errors1.yaml
+++ b/tests/data/config_with_errors1.yaml
@@ -8,6 +8,8 @@ TestProcedures:
     Classes:
       - A
       - DR-A
+    TargetVersions:
+      - v1.2
     Preconditions:
       db: config/preconditions/ALL-01.sql
     Steps:

--- a/tests/data/config_with_errors2.yaml
+++ b/tests/data/config_with_errors2.yaml
@@ -8,6 +8,8 @@ TestProcedures:
     Classes:
       - A
       - DR-A
+    TargetVersions:
+      - v1.2
     Preconditions:
       db: config/preconditions/ALL-01.sql
     Steps:

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -18,9 +18,22 @@ from cactus_test_definitions import variable_expressions as varexps
         (Action("enable-steps", {"steps": ["other-step"], "unused-param": 123}), False),  # extra param
         (Action("set-default-der-control", {}), True),
         (Action("set-default-der-control", {"opModImpLimW": 12.3, "opModExpLimW": 14}), True),
+        # storage extension specific
+        (
+            Action("set-default-der-control", {"opModImpLimW": 12.3, "opModExpLimW": 14, "opModStorageTargetW": 200}),
+            True,
+        ),
         (Action("set-default-der-control", {"opModImpLimW": 12.3, "opModExpLimW": "Invalid"}), False),  # bad type
         (Action("create-der-control", {"start": datetime(2022, 1, 3)}), False),  # Missing duration_seconds
         (Action("create-der-control", {"start": datetime(2022, 1, 3), "duration_seconds": 123}), True),
+        # storage extension specific
+        (
+            Action(
+                "create-der-control",
+                {"start": datetime(2022, 1, 3), "duration_seconds": 123, "opModStorageTargetW": 1.5},
+            ),
+            True,
+        ),
     ],
 )
 def test_validate_action_parameters(action: Action, is_valid: bool):
@@ -42,3 +55,18 @@ def test_action_expression() -> None:
     assert check_set_max_w.operation == varexps.OperationType.EQ
     assert check_set_max_w.lhs_operand == varexps.NamedVariable(varexps.NamedVariableType.DERSETTING_SET_MAX_W)
     assert check_set_max_w.rhs_operand == varexps.NamedVariable(varexps.NamedVariableType.DERCAPABILITY_RTG_MAX_W)
+
+
+def test_action_expression_using_storage_extension() -> None:
+    """Tests the creation of an Action that has an expression as one of its parameters.
+
+    Using storage extension params."""
+    type_str = "some_action"
+    params = {"setMinWh": "$(this <= setMaxWh)"}
+    action = Action(type_str, params)
+
+    check_set_min_wh = action.parameters["setMinWh"]
+    assert isinstance(check_set_min_wh, varexps.Expression)
+    assert check_set_min_wh.operation == varexps.OperationType.LTE
+    assert check_set_min_wh.lhs_operand == varexps.NamedVariable(varexps.NamedVariableType.DERSETTING_SET_MIN_WH)
+    assert check_set_min_wh.rhs_operand == varexps.NamedVariable(varexps.NamedVariableType.DERSETTING_SET_MAX_WH)

--- a/tests/unit/test_checks.py
+++ b/tests/unit/test_checks.py
@@ -23,6 +23,7 @@ from cactus_test_definitions import variable_expressions as varexps
         (Check("der-settings-contents", {"vppModesEnabled_unset": "1"}), True),
         (Check("der-capability-contents", {"vppModesSupported_set": "1"}), True),
         (Check("der-capability-contents", {"vppModesSupported_unset": "1"}), True),
+        (Check("readings-der-stored-energy", {"minimum_count": 3}), True),
     ],
 )
 def test_validate_check_parameters(check: Check, is_valid: bool):

--- a/tests/unit/test_checks.py
+++ b/tests/unit/test_checks.py
@@ -18,6 +18,11 @@ from cactus_test_definitions import variable_expressions as varexps
         (Check("der-settings-contents", {"modesEnabled_unset": "E"}), True),
         (Check("der-settings-contents", {"doeModesEnabled_set": 12}), False),
         (Check("der-settings-contents", {"doeModesEnabled_unset": 12}), False),
+        # Storage extension
+        (Check("der-settings-contents", {"vppModesEnabled_set": "1"}), True),
+        (Check("der-settings-contents", {"vppModesEnabled_unset": "1"}), True),
+        (Check("der-capability-contents", {"vppModesSupported_set": "1"}), True),
+        (Check("der-capability-contents", {"vppModesSupported_unset": "1"}), True),
     ],
 )
 def test_validate_check_parameters(check: Check, is_valid: bool):

--- a/tests/unit/test_test_procedures.py
+++ b/tests/unit/test_test_procedures.py
@@ -4,6 +4,10 @@ from cactus_test_definitions.test_procedures import (
     TestProcedureConfig,
     TestProcedureId,
 )
+from cactus_test_definitions.variable_expressions import (
+    NamedVariableType,
+    has_named_variable,
+)
 
 # Failures here will raise an issue in the test_from_yamlfile test
 ALL_TEST_PROCEDURES: list[tuple[str, TestProcedure]] = []
@@ -115,3 +119,36 @@ def test_each_step_connected(tp_id: str, tp: TestProcedure):
     assert (
         step_names == visited_nodes
     ), "Missing entries here indicate a step (or steps) that can't be reached from the root node"
+
+
+@pytest.mark.parametrize("tp_id, tp", ALL_TEST_PROCEDURES)
+def test_procedures_have_required_preconditions(tp_id: str, tp: TestProcedure):
+
+    # Check 'end-device-contents' present
+    enddevice_not_required = [
+        "ALL-01",  # Out-of-band device registration
+        "ALL-02",  # In-band registration during test procedure
+        "OPT-1-IN-BAND",  # In-band device registration during test procedure
+        "OPT-1-OUT-OF-BAND",  # Out-of-band device registration
+        "ALL-04",  # In-band device registration during test procedure
+        "DRA-01",  # In-band device registration during test procedure (implied)
+    ]
+    if tp_id not in enddevice_not_required:
+        assert tp.preconditions is not None
+        assert tp.preconditions.checks is not None
+        assert any([check.type == "end-device-contents" for check in tp.preconditions.checks])
+
+    # Check 'der-settings-contents' present if any precondition action parameter references setMaxW
+    if tp.preconditions is not None and tp.preconditions.actions is not None:
+        for action in tp.preconditions.actions:
+            if action.parameters is not None:
+                if any(
+                    [
+                        has_named_variable(
+                            parameter_value=parameter, named_variable=NamedVariableType.DERSETTING_SET_MAX_W
+                        )
+                        for parameter in action.parameters.values()
+                    ]
+                ):
+                    assert tp.preconditions.checks is not None
+                    assert any([check.type == "der-settings-contents" for check in tp.preconditions.checks])

--- a/tests/unit/test_test_procedures.py
+++ b/tests/unit/test_test_procedures.py
@@ -132,6 +132,7 @@ def test_procedures_have_required_preconditions(tp_id: str, tp: TestProcedure):
         "OPT-1-OUT-OF-BAND",  # Out-of-band device registration
         "ALL-04",  # In-band device registration during test procedure
         "DRA-01",  # In-band device registration during test procedure (implied)
+        "BES-02",  # In-band device registration during test procedure
     ]
     if tp_id not in enddevice_not_required:
         assert tp.preconditions is not None

--- a/tests/unit/test_variable_expressions.py
+++ b/tests/unit/test_variable_expressions.py
@@ -211,6 +211,19 @@ def test_parse_time_delta(unquoted_raw: str, expected: timedelta | type[Exceptio
         ("7 + + 8 ", UnparseableVariableExpressionError),
         ("'5 mins + now ", UnparseableVariableExpressionError),  # Unterminated string literal
         ("now + '5 mins", UnparseableVariableExpressionError),  # Unterminated string literal
+        # Storage extension
+        (
+            "setMinWh >= 0.5",
+            Expression(OperationType.GTE, NamedVariable(NamedVariableType.DERSETTING_SET_MIN_WH), Constant(0.5)),
+        ),
+        (
+            "negRtgMaxChargeRateW + 50",
+            Expression(
+                OperationType.ADD,
+                NamedVariable(NamedVariableType.DERCAPABILITY_NEG_RTG_MAX_CHARGE_RATE_W),
+                Constant(50),
+            ),
+        ),
     ],
 )
 def test_parse_variable_expression_body(

--- a/tests/unit/test_variable_expressions.py
+++ b/tests/unit/test_variable_expressions.py
@@ -11,6 +11,7 @@ from cactus_test_definitions.variable_expressions import (
     NamedVariableType,
     OperationType,
     UnparseableVariableExpressionError,
+    has_named_variable,
     is_resolvable_variable,
     parse_time_delta,
     parse_variable_expression_body,
@@ -295,5 +296,42 @@ def test_parse_variable_expression_body_this(
 )
 def test_is_resolvable_variable(input: Any, expected: bool):
     result = is_resolvable_variable(input)
+    assert isinstance(result, bool)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "parameter,variable,expected",
+    [
+        (Constant(value=0), NamedVariableType.DERSETTING_SET_MAX_W, False),
+        (Constant(value=5), NamedVariableType.DERSETTING_SET_MAX_W, False),
+        (NamedVariable(NamedVariableType.DERSETTING_SET_MAX_W), NamedVariableType.DERSETTING_SET_MAX_W, True),
+        (NamedVariable(NamedVariableType.DERSETTING_SET_MAX_VA), NamedVariableType.DERSETTING_SET_MAX_W, False),
+        (
+            Expression(OperationType.ADD, Constant(1.23), NamedVariable(NamedVariableType.NOW)),
+            NamedVariableType.DERSETTING_SET_MAX_W,
+            False,
+        ),
+        (
+            Expression(OperationType.ADD, NamedVariable(NamedVariableType.NOW), Constant(1.23)),
+            NamedVariableType.DERSETTING_SET_MAX_W,
+            False,
+        ),
+        (
+            Expression(OperationType.ADD, Constant(1.23), NamedVariable(NamedVariableType.DERSETTING_SET_MAX_W)),
+            NamedVariableType.DERSETTING_SET_MAX_W,
+            True,
+        ),
+        (
+            Expression(OperationType.ADD, NamedVariable(NamedVariableType.DERSETTING_SET_MAX_W), Constant(1.23)),
+            NamedVariableType.DERSETTING_SET_MAX_W,
+            True,
+        ),
+    ],
+)
+def test_has_named_variable(
+    parameter: NamedVariable | Expression | Constant, variable: NamedVariableType, expected: bool
+):
+    result = has_named_variable(parameter_value=parameter, named_variable=variable)
     assert isinstance(result, bool)
     assert result == expected


### PR DESCRIPTION
This will bring the storage extension branch into the BSGIP main. New tests include BES-01 -> BES-04. Adds all storage extension check variables including:
- `vppModesEnabled`
- `vppModesSupported`
- `setMinWh`

As well as action control action variable `opModStorageTargetW`

Closes AB#197946