### PR TITLE
DERStatus/DERSettings/DERCapability to expect PUT instead of POST

### DIFF
--- a/cactus_test_definitions/procedures/ALL-07.yaml
+++ b/cactus_test_definitions/procedures/ALL-07.yaml
@@ -32,11 +32,11 @@ Preconditions:
 Steps:
   
   # (b, c)
-  POST-DERSTATUS-DISCONNECT:
+  PUT-DERSTATUS-DISCONNECT:
     instructions:
       - Disconnect all DER from the grid.
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -49,18 +49,18 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-CONNECT
+            - PUT-DERSTATUS-CONNECT
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-DISCONNECT
+            - PUT-DERSTATUS-DISCONNECT
   
   # (d, e)
-  POST-DERSTATUS-CONNECT:
+  PUT-DERSTATUS-CONNECT:
     instructions:
       - Reconnect all DER to the grid.
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -73,4 +73,4 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-CONNECT
+            - PUT-DERSTATUS-CONNECT

--- a/cactus_test_definitions/procedures/ALL-08.yaml
+++ b/cactus_test_definitions/procedures/ALL-08.yaml
@@ -34,11 +34,11 @@ Preconditions:
 Steps:
   
   # (c, d)
-  POST-DERSTATUS-DISCONNECT:
+  PUT-DERSTATUS-DISCONNECT:
     instructions:
       - Stop DER from generating or consuming active power. (e.g. power source/sink is set to 0W)
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -51,18 +51,18 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-CONNECT
+            - PUT-DERSTATUS-CONNECT
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-DISCONNECT
+            - PUT-DERSTATUS-DISCONNECT
   
   # (e, f)
-  POST-DERSTATUS-CONNECT:
+  PUT-DERSTATUS-CONNECT:
     instructions:
       - Re-enable ability of DER to generate or consume active power.
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -75,4 +75,4 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-CONNECT
+            - PUT-DERSTATUS-CONNECT

--- a/cactus_test_definitions/procedures/ALL-11.yaml
+++ b/cactus_test_definitions/procedures/ALL-11.yaml
@@ -53,7 +53,7 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-DISCONNECT
+            - PUT-DERSTATUS-DISCONNECT
             - WAIT-CONTROL-END
       - type: remove-steps
         parameters:
@@ -61,9 +61,9 @@ Steps:
             - WAIT-CONTROL-START
   
   # (c)
-  POST-DERSTATUS-DISCONNECT:
+  PUT-DERSTATUS-DISCONNECT:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -75,7 +75,7 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-DISCONNECT
+            - PUT-DERSTATUS-DISCONNECT
 
   # (d) - This is soley to prevent a client from reporting reconnect too early
   WAIT-CONTROL-END:
@@ -87,16 +87,16 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-RECONNECT
+            - PUT-DERSTATUS-RECONNECT
       - type: remove-steps
         parameters:
           steps:
             - WAIT-CONTROL-END
 
   # (d)
-  POST-DERSTATUS-RECONNECT:
+  PUT-DERSTATUS-RECONNECT:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -108,4 +108,4 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-RECONNECT
+            - PUT-DERSTATUS-RECONNECT

--- a/cactus_test_definitions/procedures/ALL-12.yaml
+++ b/cactus_test_definitions/procedures/ALL-12.yaml
@@ -45,16 +45,16 @@ Steps:
         parameters:
           steps:
             - WAIT-TILL-END
-            - POST-DERSTATUS-DISCONNECT
+            - PUT-DERSTATUS-DISCONNECT
       - type: remove-steps
         parameters:
           steps:
             - GET-DERC
 
   # (c) This will wait until the client POST's a DERStatus saying it has disconnected
-  POST-DERSTATUS-DISCONNECT:
+  PUT-DERSTATUS-DISCONNECT:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -66,16 +66,16 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-RECONNECT
+            - PUT-DERSTATUS-RECONNECT
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-DISCONNECT
+            - PUT-DERSTATUS-DISCONNECT
 
   # (d) This will wait until the client POST's a DERStatus saying it has reconnected
-  POST-DERSTATUS-RECONNECT:
+  PUT-DERSTATUS-RECONNECT:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -87,7 +87,7 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-RECONNECT
+            - PUT-DERSTATUS-RECONNECT
   
   WAIT-TILL-END:
     event:

--- a/cactus_test_definitions/procedures/ALL-13.yaml
+++ b/cactus_test_definitions/procedures/ALL-13.yaml
@@ -51,7 +51,7 @@ Steps:
         parameters:
           steps:
             - GET-DEFAULT-DERC-UPDATED
-            - POST-DERSETTINGS-SET-GRAD-W
+            - PUT-DERSETTINGS-SET-GRAD-W
       - type: remove-steps
         parameters:
           steps:
@@ -59,9 +59,9 @@ Steps:
 
   # (c)
   # This will wait until the client POST's a DERSettings with the 1% setGradW
-  POST-DERSETTINGS-SET-GRAD-W:
+  PUT-DERSETTINGS-SET-GRAD-W:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/derg
         serve_request_first: true # Run this AFTER server receives the request
@@ -73,7 +73,7 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSETTINGS-SET-GRAD-W
+            - PUT-DERSETTINGS-SET-GRAD-W
 
   # (b)
   GET-DEFAULT-DERC-UPDATED:
@@ -85,16 +85,16 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSETTINGS-SET-GRAD-W-DEFAULT
+            - PUT-DERSETTINGS-SET-GRAD-W-DEFAULT
       - type: remove-steps
         parameters:
           steps:
             - GET-DEFAULT-DERC-UPDATED
 
   # This will wait until the client POST's a DERSettings with the 0.27% setGradW
-  POST-DERSETTINGS-SET-GRAD-W-DEFAULT:
+  PUT-DERSETTINGS-SET-GRAD-W-DEFAULT:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -106,5 +106,5 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSETTINGS-SET-GRAD-W-DEFAULT
+            - PUT-DERSETTINGS-SET-GRAD-W-DEFAULT
  

--- a/cactus_test_definitions/procedures/ALL-15.yaml
+++ b/cactus_test_definitions/procedures/ALL-15.yaml
@@ -49,9 +49,9 @@ Preconditions:
 Steps:
 
   # (c, d)
-  POST-DERSTATUS-DEENERGIZE:
+  PUT-DERSTATUS-DEENERGIZE:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -64,7 +64,7 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-ENERGIZE
+            - PUT-DERSTATUS-ENERGIZE
             - WAIT-TEST-END
       - type: create-der-control
         parameters:
@@ -74,12 +74,12 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-DEENERGIZE
+            - PUT-DERSTATUS-DEENERGIZE
 
   # (f)
-  POST-DERSTATUS-ENERGIZE:
+  PUT-DERSTATUS-ENERGIZE:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -92,7 +92,7 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-ENERGIZE
+            - PUT-DERSTATUS-ENERGIZE
 
   # (e) We give the client a minute to respond with a re-energize
   WAIT-TEST-END:

--- a/cactus_test_definitions/procedures/ALL-16.yaml
+++ b/cactus_test_definitions/procedures/ALL-16.yaml
@@ -42,9 +42,9 @@ Preconditions:
 Steps:
   
   # (c, d)
-  POST-DERSTATUS-DISCONNECT:
+  PUT-DERSTATUS-DISCONNECT:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -57,7 +57,7 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-CONNECT
+            - PUT-DERSTATUS-CONNECT
             - WAIT-TEST-END
       - type: create-der-control
         parameters:
@@ -67,12 +67,12 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-DISCONNECT
+            - PUT-DERSTATUS-DISCONNECT
 
   # (f)
-  POST-DERSTATUS-CONNECT:
+  PUT-DERSTATUS-CONNECT:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -85,7 +85,7 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-CONNECT
+            - PUT-DERSTATUS-CONNECT
 
   # (e) We give the client a minute to respond with a reconnect
   WAIT-TEST-END:

--- a/cactus_test_definitions/procedures/ALL-17.yaml
+++ b/cactus_test_definitions/procedures/ALL-17.yaml
@@ -46,9 +46,9 @@ Steps:
   
   # (b, c)
   # This will wait until the client POST's a DERSettings with the 1% setGradW
-  POST-DERSETTINGS-SET-GRAD-W:
+  PUT-DERSETTINGS-SET-GRAD-W:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/derg
         serve_request_first: true # Run this AFTER server receives the request
@@ -60,4 +60,4 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSETTINGS-SET-GRAD-W
+            - PUT-DERSETTINGS-SET-GRAD-W

--- a/cactus_test_definitions/procedures/ALL-26.yaml
+++ b/cactus_test_definitions/procedures/ALL-26.yaml
@@ -53,16 +53,16 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-DISCONNECT
+            - PUT-DERSTATUS-DISCONNECT
       - type: remove-steps
         parameters:
           steps:
             - GET-DERC
 
   # (c, d)
-  POST-DERSTATUS-DISCONNECT:
+  PUT-DERSTATUS-DISCONNECT:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -75,7 +75,7 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-DISCONNECT
+            - PUT-DERSTATUS-DISCONNECT
       - type: create-der-control
         parameters:
           start: $(now)
@@ -84,12 +84,12 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-CONNECT
+            - PUT-DERSTATUS-CONNECT
 
   # (e)
-  POST-DERSTATUS-CONNECT:
+  PUT-DERSTATUS-CONNECT:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -102,6 +102,6 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-CONNECT
+            - PUT-DERSTATUS-CONNECT
 
   

--- a/cactus_test_definitions/procedures/ALL-27.yaml
+++ b/cactus_test_definitions/procedures/ALL-27.yaml
@@ -51,16 +51,16 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-DISCONNECT
+            - PUT-DERSTATUS-DISCONNECT
       - type: remove-steps
         parameters:
           steps:
             - GET-DERC
 
   # (c, d)
-  POST-DERSTATUS-DISCONNECT:
+  PUT-DERSTATUS-DISCONNECT:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -73,7 +73,7 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-DISCONNECT
+            - PUT-DERSTATUS-DISCONNECT
       - type: create-der-control
         parameters:
           start: $(now)
@@ -82,12 +82,12 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-CONNECT
+            - PUT-DERSTATUS-CONNECT
 
   # (e)
-  POST-DERSTATUS-CONNECT:
+  PUT-DERSTATUS-CONNECT:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -100,6 +100,6 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-CONNECT
+            - PUT-DERSTATUS-CONNECT
 
   

--- a/cactus_test_definitions/procedures/ALL-28.yaml
+++ b/cactus_test_definitions/procedures/ALL-28.yaml
@@ -116,16 +116,16 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSETTINGS-SET-GRAD-W
+            - PUT-DERSETTINGS-SET-GRAD-W
       - type: remove-steps
         parameters:
           steps:
             - GET-DEFAULT-DERC
 
   # (f, g)
-  POST-DERSETTINGS-SET-GRAD-W:
+  PUT-DERSETTINGS-SET-GRAD-W:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/derg
         serve_request_first: true # Run this AFTER server receives the request
@@ -143,7 +143,7 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSETTINGS-SET-GRAD-W
+            - PUT-DERSETTINGS-SET-GRAD-W
 
   # (h)
   POST-RESPONSE-CANCELLED:

--- a/cactus_test_definitions/procedures/DRA-01.yaml
+++ b/cactus_test_definitions/procedures/DRA-01.yaml
@@ -34,21 +34,21 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DER-CAPABILITY
+            - PUT-DER-CAPABILITY
       - type: remove-steps
         parameters:
           steps:
             - GET-DER
 
-  POST-DER-CAPABILITY:
+  PUT-DER-CAPABILITY:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/dercap
     actions:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DER-CAPABILITY
+            - PUT-DER-CAPABILITY
 
   

--- a/cactus_test_definitions/procedures/DRA-02.yaml
+++ b/cactus_test_definitions/procedures/DRA-02.yaml
@@ -39,16 +39,16 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS
+            - PUT-DERSTATUS
       - type: remove-steps
         parameters:
           steps:
             - GET-DERC
 
   # (b)
-  POST-DERSTATUS:
+  PUT-DERSTATUS:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -61,4 +61,4 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS
+            - PUT-DERSTATUS

--- a/cactus_test_definitions/procedures/DRD-01.yaml
+++ b/cactus_test_definitions/procedures/DRD-01.yaml
@@ -41,16 +41,16 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-1
+            - PUT-DERSTATUS-1
       - type: remove-steps
         parameters:
           steps:
             - GET-DERC-1
 
   # (c) Wait for the update to DERStatus
-  POST-DERSTATUS-1:
+  PUT-DERSTATUS-1:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -67,7 +67,7 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-1
+            - PUT-DERSTATUS-1
       
   # (d, e, f) Create DERControl with immediate start to reconnect and then a second DERControl
   GET-DERC-2:
@@ -89,8 +89,8 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-2
-            - POST-DERSETTINGS-2
+            - PUT-DERSTATUS-2
+            - PUT-DERSETTINGS-2
             - WAIT-DERC-2
       - type: remove-steps
         parameters:
@@ -98,9 +98,9 @@ Steps:
             - GET-DERC-2
   
   # (g, h)
-  POST-DERSTATUS-2:
+  PUT-DERSTATUS-2:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -113,12 +113,12 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-2
+            - PUT-DERSTATUS-2
 
   # (g, h)
-  POST-DERSETTINGS-2:
+  PUT-DERSETTINGS-2:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/derg
         serve_request_first: true # Run this AFTER server receives the request
@@ -130,7 +130,7 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSETTINGS-2
+            - PUT-DERSETTINGS-2
 
   # (i) After the end of the previous control...
   WAIT-DERC-2:
@@ -163,8 +163,8 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-3
-            - POST-DERSETTINGS-3
+            - PUT-DERSTATUS-3
+            - PUT-DERSETTINGS-3
             - WAIT-DERC-3
       - type: remove-steps
         parameters:
@@ -172,9 +172,9 @@ Steps:
             - GET-DERC-3
 
   # (k)
-  POST-DERSTATUS-3:
+  PUT-DERSTATUS-3:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -187,12 +187,12 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-3
+            - PUT-DERSTATUS-3
 
   # (k)
-  POST-DERSETTINGS-3:
+  PUT-DERSETTINGS-3:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/derg
         serve_request_first: true # Run this AFTER server receives the request
@@ -204,7 +204,7 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSETTINGS-3
+            - PUT-DERSETTINGS-3
 
 
   # (l) After the end of the previous control...
@@ -238,8 +238,8 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-4
-            - POST-DERSETTINGS-4
+            - PUT-DERSTATUS-4
+            - PUT-DERSETTINGS-4
             - WAIT-DERC-4
       - type: remove-steps
         parameters:
@@ -248,9 +248,9 @@ Steps:
 
 
   # (m, n)
-  POST-DERSTATUS-4:
+  PUT-DERSTATUS-4:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -263,12 +263,12 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-4
+            - PUT-DERSTATUS-4
 
   # (m, n)
-  POST-DERSETTINGS-4:
+  PUT-DERSETTINGS-4:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/derg
         serve_request_first: true # Run this AFTER server receives the request
@@ -280,7 +280,7 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSETTINGS-4
+            - PUT-DERSETTINGS-4
 
   # (o) After the end of the previous control...
   WAIT-DERC-4:
@@ -314,8 +314,8 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-5
-            - POST-DERSETTINGS-5
+            - PUT-DERSTATUS-5
+            - PUT-DERSETTINGS-5
             - WAIT-DERC-5
       - type: remove-steps
         parameters:
@@ -323,9 +323,9 @@ Steps:
             - GET-DERC-5
 
   # (p, q)
-  POST-DERSTATUS-5:
+  PUT-DERSTATUS-5:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -338,12 +338,12 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-5
+            - PUT-DERSTATUS-5
 
   # (p, q)
-  POST-DERSETTINGS-5:
+  PUT-DERSETTINGS-5:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/derg
         serve_request_first: true # Run this AFTER server receives the request
@@ -355,7 +355,7 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSETTINGS-5
+            - PUT-DERSETTINGS-5
 
   # (r) After the end of the previous control...
   WAIT-DERC-5:
@@ -388,8 +388,8 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-6
-            - POST-DERSETTINGS-6
+            - PUT-DERSTATUS-6
+            - PUT-DERSETTINGS-6
             - WAIT-DERC-6
       - type: remove-steps
         parameters:
@@ -397,9 +397,9 @@ Steps:
             - GET-DERC-6
 
   # (s, t)
-  POST-DERSTATUS-6:
+  PUT-DERSTATUS-6:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -412,12 +412,12 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-6
+            - PUT-DERSTATUS-6
 
   # (s, t)
-  POST-DERSETTINGS-6:
+  PUT-DERSETTINGS-6:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/derg
         serve_request_first: true # Run this AFTER server receives the request
@@ -429,7 +429,7 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSETTINGS-6
+            - PUT-DERSETTINGS-6
 
   # (u) After the end of the previous control...
   WAIT-DERC-6:
@@ -462,8 +462,8 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-7
-            - POST-DERSETTINGS-7
+            - PUT-DERSTATUS-7
+            - PUT-DERSETTINGS-7
             - WAIT-DERC-7
       - type: remove-steps
         parameters:
@@ -471,9 +471,9 @@ Steps:
             - GET-DERC-7
 
   # (v, w)
-  POST-DERSTATUS-7:
+  PUT-DERSTATUS-7:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -486,12 +486,12 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-7
+            - PUT-DERSTATUS-7
 
   # (v, w)
-  POST-DERSETTINGS-7:
+  PUT-DERSETTINGS-7:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/derg
         serve_request_first: true # Run this AFTER server receives the request
@@ -503,7 +503,7 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSETTINGS-7
+            - PUT-DERSETTINGS-7
 
   # (x) After the end of the previous control...
   WAIT-DERC-7:
@@ -536,8 +536,8 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-8
-            - POST-DERSETTINGS-8
+            - PUT-DERSTATUS-8
+            - PUT-DERSETTINGS-8
             - WAIT-DERC-8
       - type: remove-steps
         parameters:
@@ -545,9 +545,9 @@ Steps:
             - GET-DERC-8
 
   # (y, z)
-  POST-DERSTATUS-8:
+  PUT-DERSTATUS-8:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -560,12 +560,12 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-8
+            - PUT-DERSTATUS-8
 
   # (y, z)
-  POST-DERSETTINGS-8:
+  PUT-DERSETTINGS-8:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/derg
         serve_request_first: true # Run this AFTER server receives the request
@@ -577,7 +577,7 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSETTINGS-8
+            - PUT-DERSETTINGS-8
 
   # (aa) After the end of the previous control...
   WAIT-DERC-8:
@@ -610,8 +610,8 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-9
-            - POST-DERSETTINGS-9
+            - PUT-DERSTATUS-9
+            - PUT-DERSETTINGS-9
             - WAIT-DERC-9
       - type: remove-steps
         parameters:
@@ -619,9 +619,9 @@ Steps:
             - GET-DERC-9
 
   # (bb, cc)
-  POST-DERSTATUS-9:
+  PUT-DERSTATUS-9:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -634,12 +634,12 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-9
+            - PUT-DERSTATUS-9
 
   # (bb, cc)
-  POST-DERSETTINGS-9:
+  PUT-DERSETTINGS-9:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/derg
         serve_request_first: true # Run this AFTER server receives the request
@@ -651,7 +651,7 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSETTINGS-9
+            - PUT-DERSETTINGS-9
   
   WAIT-DERC-9:
     event:

--- a/cactus_test_definitions/procedures/DRL-01.yaml
+++ b/cactus_test_definitions/procedures/DRL-01.yaml
@@ -43,8 +43,8 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-1
-            - POST-DERSETTINGS-1
+            - PUT-DERSTATUS-1
+            - PUT-DERSETTINGS-1
             - WAIT-DERC-1
       - type: remove-steps
         parameters:
@@ -52,9 +52,9 @@ Steps:
             - GET-DERC-1
 
   # (c)
-  POST-DERSTATUS-1:
+  PUT-DERSTATUS-1:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -67,12 +67,12 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-1
+            - PUT-DERSTATUS-1
 
   # (c)
-  POST-DERSETTINGS-1:
+  PUT-DERSETTINGS-1:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/derg
         serve_request_first: true # Run this AFTER server receives the request
@@ -84,7 +84,7 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSETTINGS-1
+            - PUT-DERSETTINGS-1
 
 
   # (d) After the end of the previous control...
@@ -118,8 +118,8 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-2
-            - POST-DERSETTINGS-2
+            - PUT-DERSTATUS-2
+            - PUT-DERSETTINGS-2
             - WAIT-DERC-2
       - type: remove-steps
         parameters:
@@ -128,9 +128,9 @@ Steps:
 
 
   # (e, f)
-  POST-DERSTATUS-2:
+  PUT-DERSTATUS-2:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -143,12 +143,12 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-2
+            - PUT-DERSTATUS-2
 
   # (e, f)
-  POST-DERSETTINGS-2:
+  PUT-DERSETTINGS-2:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/derg
         serve_request_first: true # Run this AFTER server receives the request
@@ -160,7 +160,7 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSETTINGS-2
+            - PUT-DERSETTINGS-2
 
   # (g) After the end of the previous control...
   WAIT-DERC-2:
@@ -194,8 +194,8 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-3
-            - POST-DERSETTINGS-3
+            - PUT-DERSTATUS-3
+            - PUT-DERSETTINGS-3
             - WAIT-DERC-3
       - type: remove-steps
         parameters:
@@ -203,9 +203,9 @@ Steps:
             - GET-DERC-3
 
   # (h, i)
-  POST-DERSTATUS-3:
+  PUT-DERSTATUS-3:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -218,12 +218,12 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-3
+            - PUT-DERSTATUS-3
 
   # (h, i)
-  POST-DERSETTINGS-3:
+  PUT-DERSETTINGS-3:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/derg
         serve_request_first: true # Run this AFTER server receives the request
@@ -235,7 +235,7 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSETTINGS-3
+            - PUT-DERSETTINGS-3
 
   # (j) After the end of the previous control...
   WAIT-DERC-3:
@@ -268,8 +268,8 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-4
-            - POST-DERSETTINGS-4
+            - PUT-DERSTATUS-4
+            - PUT-DERSETTINGS-4
             - WAIT-DERC-4
       - type: remove-steps
         parameters:
@@ -277,9 +277,9 @@ Steps:
             - GET-DERC-4
 
   # (k, l)
-  POST-DERSTATUS-4:
+  PUT-DERSTATUS-4:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -292,12 +292,12 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-4
+            - PUT-DERSTATUS-4
 
   # (k, l)
-  POST-DERSETTINGS-4:
+  PUT-DERSETTINGS-4:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/derg
         serve_request_first: true # Run this AFTER server receives the request
@@ -309,7 +309,7 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSETTINGS-4
+            - PUT-DERSETTINGS-4
 
   # Wait for the controls to finish
   WAIT-DERC-4:

--- a/cactus_test_definitions/procedures/MUL-01.yaml
+++ b/cactus_test_definitions/procedures/MUL-01.yaml
@@ -42,11 +42,11 @@ Preconditions:
 Steps:
   
   # The client powers off one DER
-  POST-DERSTATUS-FIRST-DISCONNECT:
+  PUT-DERSTATUS-FIRST-DISCONNECT:
     instructions:
       - Power off one DER either by a hardware switch on the DER or by disconnection from the grid supply. Priority should be given to DER capable of generation.
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -62,18 +62,18 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSTATUS-FULL-DISCONNECT
+            - PUT-DERSTATUS-FULL-DISCONNECT
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-FIRST-DISCONNECT
+            - PUT-DERSTATUS-FIRST-DISCONNECT
   
   # The client powers off all remaining DER
-  POST-DERSTATUS-FULL-DISCONNECT:
+  PUT-DERSTATUS-FULL-DISCONNECT:
     instructions:
       - Power off off remaining DER.
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/ders
         serve_request_first: true # Run this AFTER server receives the request
@@ -89,4 +89,4 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSTATUS-FULL-DISCONNECT
+            - PUT-DERSTATUS-FULL-DISCONNECT

--- a/cactus_test_definitions/procedures/MUL-03.yaml
+++ b/cactus_test_definitions/procedures/MUL-03.yaml
@@ -40,9 +40,9 @@ Preconditions:
 Steps:
   
   # (a, b, c)
-  POST-DERSETTINGS-FIRST:
+  PUT-DERSETTINGS-FIRST:
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/derg
     actions:
@@ -52,18 +52,18 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSETTINGS-FIRST
+            - PUT-DERSETTINGS-FIRST
       - type: enable-steps
         parameters:
           steps:
-            - POST-DERSETTINGS-UPDATED
+            - PUT-DERSETTINGS-UPDATED
       
   # (d)
-  POST-DERSETTINGS-UPDATED:
+  PUT-DERSETTINGS-UPDATED:
     instructions:
       - Modify the maximum rating of one DER in the device settings.
     event:
-      type: POST-request-received
+      type: PUT-request-received
       parameters:
         endpoint: /edev/1/der/1/derg
         serve_request_first: true
@@ -75,4 +75,4 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - POST-DERSETTINGS-UPDATED
+            - PUT-DERSETTINGS-UPDATED


### PR DESCRIPTION
* Expanding https://github.com/bsgip/cactus-test-definitions/pull/20

SA TS 5573 has some incorrect references for requiring a POST to `DERCapability` / `DERSetting` / `DERStatus` resources (2030.5 clearly expects a PUT with POST being treated as an error)

This takes the work initially highlighted by Fronius and applies it to the remaining test cases