### PR TITLE
Revert "Ensuring all "valid" PINs are now 111115"

### DIFF
--- a/cactus_test_definitions/procedures/ALL-03-REJ.yaml
+++ b/cactus_test_definitions/procedures/ALL-03-REJ.yaml
@@ -32,8 +32,6 @@ Preconditions:
 Steps:
   # (a, b, c)
   GET-REGISTRATION:
-    instructions:
-      - "An EndDevice has already been registered (out of band) with a different PIN from ALL-01"
     event:
       type: GET-request-received
       parameters:

--- a/cactus_test_definitions/procedures/ALL-04.yaml
+++ b/cactus_test_definitions/procedures/ALL-04.yaml
@@ -26,14 +26,12 @@ Preconditions:
   actions:
     - type: register-end-device
       parameters:
-        registration_pin: 11111 # With checksum is 111115
+        registration_pin: 11223
 
 
 Steps:
   # (e, f, g)
   GET-REGISTRATION:
-    instructions:
-      - "An EndDevice has already been registered (out of band) with PIN 111115"
     event:
       type: GET-request-received
       parameters:

--- a/cactus_test_definitions/procedures/OPT-1-OUT-OF-BAND.yaml
+++ b/cactus_test_definitions/procedures/OPT-1-OUT-OF-BAND.yaml
@@ -21,7 +21,7 @@ Preconditions:
   actions:
     - type: register-end-device
       parameters:
-        registration_pin: 11111 # With checksum is 111115
+        registration_pin: 11223
 
 Criteria:
   checks:
@@ -33,8 +33,6 @@ Criteria:
       
 Steps:
   GET-DCAP:
-    instructions:
-      - "An EndDevice has already been registered (out of band) with PIN 111115"
     event:
       type: GET-request-received
       parameters:


### PR DESCRIPTION
Reverts bsgip/cactus-test-definitions#22