### PR TITLE
fix: reducing reading count in line with 1.2 procedures reduction

### DIFF
--- a/cactus_test_definitions/procedures/BES-01.yaml
+++ b/cactus_test_definitions/procedures/BES-01.yaml
@@ -12,9 +12,9 @@ Criteria:
       parameters: {}
 
     # Test includes ~ 5 minutes of waiting + initial reading sent during test
-    # A minimum of 5 readings is required by the test procedure
+    # A minimum of 4 readings is required by the test procedure
     - type: readings-der-stored-energy
-      parameters: { "minimum_count": 5 }
+      parameters: { "minimum_count": 4 }
 
 Preconditions:
   init_actions:


### PR DESCRIPTION
Thinking this was the only required change as suggested in chats with @joshvote. Let me know if you believe there was something else. Our interconnection procedure states a minimum of 4 times. 

Closes AB#204216