### PR TITLE
Added a PRECONDITION-STARTUP to the witness tests

### DIFF
--- a/cactus_test_definitions/client/procedures/ALL-26.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-26.yaml
@@ -28,16 +28,56 @@ Preconditions:
     - type: der-settings-contents
       parameters: {}
   actions:
-    - type: create-der-control
+    - type: create-der-program
       parameters:
-        start: $(now)
-        duration_seconds: 300
-        opModExpLimW: $(setMaxW * 2)
-        opModImpLimW: $(setMaxW * 2)
+        primacy: 0
   instructions:
     - DER shall be exporting or importing at least 50% of its active power rating at the connection point.
     
 Steps:
+  
+  # (precondition)
+  PRECONDITION-STARTUP:
+    instructions:
+      - This step is to give time for the DER to start importing/exporting at least 50% of its rated power.
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now)
+          duration_seconds: 120
+          opModExpLimW: $(setMaxW * 2)
+          opModImpLimW: $(setMaxW * 2)
+      - type: enable-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP-WAIT
+      - type: remove-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP
+  
+  # (precondition)
+  PRECONDITION-STARTUP-WAIT:
+    instructions:
+      - This step is to give time for the DER to start importing/exporting at least 50% of its rated power.
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC
+      - type: remove-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP-WAIT
+
   # (a, b)
   GET-DERC:
     event:

--- a/cactus_test_definitions/client/procedures/ALL-27.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-27.yaml
@@ -28,14 +28,53 @@ Preconditions:
     - type: der-settings-contents
       parameters: {}
   actions:
-    - type: create-der-control
+    - type: create-der-program
       parameters:
-        start: $(now)
-        duration_seconds: 300
-        opModExpLimW: $(setMaxW * 2)
-        opModImpLimW: $(setMaxW * 2)
+        primacy: 0
     
 Steps:
+  # (precondition)
+  PRECONDITION-STARTUP:
+    instructions:
+      - This step is to give time for the DER to start importing/exporting at least 50% of its rated power.
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now)
+          duration_seconds: 120
+          opModExpLimW: $(setMaxW * 2)
+          opModImpLimW: $(setMaxW * 2)
+      - type: enable-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP-WAIT
+      - type: remove-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP
+  
+  # (precondition)
+  PRECONDITION-STARTUP-WAIT:
+    instructions:
+      - This step is to give time for the DER to start importing/exporting at least 50% of its rated power.
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC
+      - type: remove-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP-WAIT
+
   # (a, b)
   GET-DERC:
     event:

--- a/cactus_test_definitions/client/procedures/ALL-28.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-28.yaml
@@ -31,10 +31,55 @@ Preconditions:
     - type: create-der-program
       parameters:
         primacy: 0  
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
   instructions:
     - DER is exporting or importing at the connection point at least 50% of its rated power.
 
 Steps:
+  # (precondition)
+  PRECONDITION-STARTUP:
+    instructions:
+      - This step is to give time for the DER to start importing/exporting at least 50% of its rated power.
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now)
+          duration_seconds: 120
+          opModExpLimW: $(setMaxW * 2)
+          opModImpLimW: $(setMaxW * 2)
+      - type: enable-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP-WAIT
+      - type: remove-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP
+  
+  # (precondition)
+  PRECONDITION-STARTUP-WAIT:
+    instructions:
+      - This step is to give time for the DER to start importing/exporting at least 50% of its rated power.
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-1
+      - type: remove-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP-WAIT
 
   # (precondition)
   GET-DERC-1:
@@ -46,7 +91,7 @@ Steps:
       - type: create-der-control
         parameters:
           start: $(now)
-          duration_seconds: 300
+          duration_seconds: 900
           opModExpLimW: $(setMaxW * 0.3)
           opModImpLimW: $(setMaxW * 0.3)
       - type: enable-steps
@@ -113,6 +158,8 @@ Steps:
       - type: set-default-der-control
         parameters:
           setGradW: 100 # hundredths of a percent - this is 1%
+          opModImpLimW: 0
+          opModExpLimW: 0
       - type: enable-steps
         parameters:
           steps:

--- a/cactus_test_definitions/client/procedures/ALL-30.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-30.yaml
@@ -41,6 +41,48 @@ Preconditions:
 
 Steps:
   
+  # (precondition)
+  PRECONDITION-STARTUP:
+    instructions:
+      - This step is to give time for the DER to start importing/exporting at least 50% of its rated power.
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now)
+          duration_seconds: 120
+          opModExpLimW: $(setMaxW * 2)
+          opModImpLimW: $(setMaxW * 2)
+      - type: enable-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP-WAIT
+      - type: remove-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP
+  
+  # (precondition)
+  PRECONDITION-STARTUP-WAIT:
+    instructions:
+      - This step is to give time for the DER to start importing/exporting at least 50% of its rated power.
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DEFAULT-DERC
+      - type: remove-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP-WAIT
+
   # (precondition) - Wait for the DefaultDERControl to be picked up
   GET-DEFAULT-DERC:
     event:

--- a/cactus_test_definitions/client/procedures/GEN-09.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-09.yaml
@@ -28,11 +28,9 @@ Preconditions:
     - type: der-settings-contents
       parameters: {}
   actions:
-    - type: create-der-control
+    - type: create-der-program
       parameters:
-        start: $(now)
-        duration_seconds: 300
-        opModExpLimW: $(setMaxW * 2)
+        primacy: 0
     - type: set-default-der-control
       parameters:
         opModExpLimW: $(setMaxW * 0.3)
@@ -40,6 +38,48 @@ Preconditions:
     - DER should be exporting at least 50% of its rated power.
     
 Steps:
+  # (precondition)
+  PRECONDITION-STARTUP:
+    instructions:
+      - This step is to give time for the DER to start importing/exporting at least 50% of its rated power.
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now)
+          duration_seconds: 120
+          opModExpLimW: $(setMaxW * 2)
+          opModImpLimW: $(setMaxW * 2)
+      - type: enable-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP-WAIT
+      - type: remove-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP
+  
+  # (precondition)
+  PRECONDITION-STARTUP-WAIT:
+    instructions:
+      - This step is to give time for the DER to start importing/exporting at least 50% of its rated power.
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC
+      - type: remove-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP-WAIT
+
   # (a, b)
   GET-DERC:
     event:

--- a/cactus_test_definitions/client/procedures/GEN-10.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-10.yaml
@@ -94,6 +94,50 @@ Preconditions:
 
 Steps:
   
+  # (precondition)
+  PRECONDITION-STARTUP:
+    instructions:
+      - This step is to give time for the DER to start importing/exporting at least 50% of its rated power.
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now)
+          duration_seconds: 120
+          opModExpLimW: $(setMaxW * 2)
+          opModImpLimW: $(setMaxW * 2)
+          fsa_id: 1
+          primacy: 1
+      - type: enable-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP-WAIT
+      - type: remove-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP
+  
+  # (precondition)
+  PRECONDITION-STARTUP-WAIT:
+    instructions:
+      - This step is to give time for the DER to start importing/exporting at least 50% of its rated power.
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DEFAULT-DERC
+      - type: remove-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP-WAIT
+
   # (a, b) - Create a Default DERControl at DERP 1 - set to 30% of max
   GET-DEFAULT-DERC:
     event:

--- a/cactus_test_definitions/client/procedures/LOA-09.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-09.yaml
@@ -28,11 +28,9 @@ Preconditions:
     - type: der-settings-contents
       parameters: {}
   actions:
-    - type: create-der-control
+    - type: create-der-program
       parameters:
-        start: $(now)
-        duration_seconds: 300
-        opModImpLimW: $(setMaxW * 2)
+        primacy: 0
     - type: set-default-der-control
       parameters:
         opModImpLimW: $(setMaxW * 0.3)
@@ -40,6 +38,48 @@ Preconditions:
     - DER should be importing at least 50% of its rated power.
     
 Steps:
+  # (precondition)
+  PRECONDITION-STARTUP:
+    instructions:
+      - This step is to give time for the DER to start importing/exporting at least 50% of its rated power.
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now)
+          duration_seconds: 120
+          opModExpLimW: $(setMaxW * 2)
+          opModImpLimW: $(setMaxW * 2)
+      - type: enable-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP-WAIT
+      - type: remove-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP
+  
+  # (precondition)
+  PRECONDITION-STARTUP-WAIT:
+    instructions:
+      - This step is to give time for the DER to start importing/exporting at least 50% of its rated power.
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC
+      - type: remove-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP-WAIT
+
   # (a, b)
   GET-DERC:
     event:

--- a/cactus_test_definitions/client/procedures/LOA-10.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-10.yaml
@@ -94,6 +94,50 @@ Preconditions:
 
 Steps:
   
+  # (precondition)
+  PRECONDITION-STARTUP:
+    instructions:
+      - This step is to give time for the DER to start importing/exporting at least 50% of its rated power.
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /edev/1/derp/1/derc
+    actions:
+      - type: create-der-control
+        parameters:
+          start: $(now)
+          duration_seconds: 120
+          opModExpLimW: $(setMaxW * 2)
+          opModImpLimW: $(setMaxW * 2)
+          fsa_id: 1
+          primacy: 1
+      - type: enable-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP-WAIT
+      - type: remove-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP
+  
+  # (precondition)
+  PRECONDITION-STARTUP-WAIT:
+    instructions:
+      - This step is to give time for the DER to start importing/exporting at least 50% of its rated power.
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DEFAULT-DERC
+      - type: remove-steps
+        parameters:
+          steps:
+            - PRECONDITION-STARTUP-WAIT
+
   # (a, b) - Create a Default DERControl at DERP 1 - set to 30% of max
   GET-DEFAULT-DERC:
     event:


### PR DESCRIPTION
* The chapter 14 tests didn't have a "reliable" method of allowing clients to properly start at "50% load/generation" before starting the main tests.
* This PR adds a non functional "startup" period to each of these tests