### PR TITLE
fix(server): time and mup resources restricted during in-band registration

### DIFF
--- a/cactus_test_definitions/server/procedures/S-ALL-02.yaml
+++ b/cactus_test_definitions/server/procedures/S-ALL-02.yaml
@@ -23,22 +23,16 @@ Steps:
       parameters:
         resources:
           - DeviceCapability
-          - Time
-          - MirrorUsagePointList
           - EndDevice
-          - DER
     checks:
       - type: discovered
         parameters:
           resources:
             - DeviceCapability
-            - Time
-            - MirrorUsagePointList
             - EndDeviceList
       - type: end-device # This will be the check that will block if there is an existing EndDevice registration
         parameters:
           matches_client: false 
-      - type: time-synced
 
   - id: REGISTER
     action: 
@@ -60,11 +54,16 @@ Steps:
       parameters:
         resources:
           - DER
+          - Time
+          - MirrorUsagePointList
     checks:
       - type: discovered
         parameters:
           links:
+            - Time
+            - MirrorUsagePointList
             - DERCapability
             - DERSettings
             - DERStatus
+      - type: time-synced
     

--- a/cactus_test_definitions/server/procedures/S-ALL-03.yaml
+++ b/cactus_test_definitions/server/procedures/S-ALL-03.yaml
@@ -10,7 +10,7 @@ Preconditions:
   required_clients:
     - id: client
       client_type: aggregator
-  
+
 Steps:
   - id: PRECONDITION
     repeat_until_pass: true
@@ -23,22 +23,16 @@ Steps:
       parameters:
         resources:
           - DeviceCapability
-          - Time
-          - MirrorUsagePointList
           - EndDevice
-          - DER
     checks:
       - type: discovered
         parameters:
           resources:
             - DeviceCapability
-            - Time
-            - MirrorUsagePointList
             - EndDeviceList
       - type: end-device # This will be the check that will block if there is an existing EndDevice registration
         parameters:
           matches_client: false 
-      - type: time-synced
 
   - id: REGISTER
     action: 
@@ -60,11 +54,15 @@ Steps:
       parameters:
         resources:
           - DER
+          - Time
+          - MirrorUsagePointList
     checks:
       - type: discovered
         parameters:
           links:
+            - Time
+            - MirrorUsagePointList
             - DERCapability
             - DERSettings
             - DERStatus
-    
+      - type: time-synced

--- a/cactus_test_definitions/server/procedures/S-ALL-56.yaml
+++ b/cactus_test_definitions/server/procedures/S-ALL-56.yaml
@@ -22,8 +22,6 @@ Steps:
       parameters:
         resources:
           - DeviceCapability
-          - Time
-          - MirrorUsagePointList
           - EndDevice
     checks:
       - type: end-device # Block UNTIL there is no existing EndDevice registration


### PR DESCRIPTION
During server testing, these tests had to be modified as resources such as Time and MirrorUsagePointList were found to be inaccessible prior to a device being registered (404). 

Further study unveiled that according to AS5385:2023 section 6.8 Table 12 that these resources are actually expected to  be restricted in the case of certification. 

I might be wrong on that interpretation, all i know is is that our server currently fails and this time i think it does so correctly. 