### PR TITLE
DRA-01 fixed restrictive device category bits

### DIFF
--- a/cactus_test_definitions/client/procedures/DRA-01.yaml
+++ b/cactus_test_definitions/client/procedures/DRA-01.yaml
@@ -14,7 +14,7 @@ Criteria:
       parameters: {}
     - type: end-device-contents
       parameters:
-        deviceCategory_anyset: '20098' # any of bits 3, 4, 7 and 17 being set (for the device type)
+        deviceCategory_anyset: '03FFFFFF' # any of the DeviceCategory bits
     - type: der-capability-contents
       parameters: 
         modesSupported_set: '80' # bit 7 is set - opModFixedW. 


### PR DESCRIPTION
Changed the any_set requirement from only accept 4 bits to ANY valid `DeviceCategory` bit flag

While TS 5573 15.2.2 (b) is ambiguous about whether ONLY those 4 bits are acceptable - 10.1 (c) uses those same values as non exhaustive examples. We're going to take the more liberal position that as long as ANY bit is set - we're accepting it as a pass.