### PR TITLE
ALL-30 cancels precondition DERControl after use

### DIFF
--- a/cactus_test_definitions/client/procedures/ALL-30.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-30.yaml
@@ -73,6 +73,9 @@ Steps:
       type: proceed
       parameters: {}
     actions:
+      # The 200% DERControl is ONLY relevant for the precondition. We want it gone for the main body of the test
+      - type: cancel-active-der-controls  
+        parameters: {}
       - type: enable-steps
         parameters:
           steps:


### PR DESCRIPTION
The precondition 200% DERControl can technically persist and become relevant if the power cycle is particularly fast. This change means that after the proceed - the control is cancelled and ONLY the DefaultDERControl will be relevant for the purposes of test (as per TS5573 test definition)