### PR TITLE
GEN10_DERC5_ramptms

### DIFF
--- a/cactus_test_definitions/client/procedures/GEN-10.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-10.yaml
@@ -480,6 +480,7 @@ Steps:
           fsa_id: 2
           primacy: 2
           tag: DERC5
+          ramp_time_seconds: 30
       - type: enable-steps
         parameters:
           steps:

--- a/cactus_test_definitions/client/procedures/LOA-10.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-10.yaml
@@ -481,6 +481,7 @@ Steps:
           fsa_id: 2
           primacy: 2
           tag: DERC5
+          ramp_time_seconds: 30
       - type: enable-steps
         parameters:
           steps:


### PR DESCRIPTION
Lets people ramp up from the disconnect status faster, avoids issue of choosing wgra vs soft limit from 4777 in the edge case of an 'active disconnection' which is a little confusing.