### PR TITLE
fix(S-ALL-43): ensure-end-device admin instruction added

### DIFF
--- a/cactus_test_definitions/server/procedures/S-ALL-43.yaml
+++ b/cactus_test_definitions/server/procedures/S-ALL-43.yaml
@@ -15,6 +15,9 @@ Steps:
     repeat_until_pass: true
     client: client
     admin_instructions:
+      - type: ensure-end-device
+        parameters:
+          registered: true
       - type: set-poll-rate
         parameters:
           resource: DeviceCapability


### PR DESCRIPTION
Wasn't in this procedure but has been in every other test procedure I have run using the admin plugin api.

Happy for it not to be either way. I will likely just implement a workaround in my code to look at the test procedure id and create the device if `== "S-ALL-43"` for now.