### PR TITLE
immediate start to avoid playlist runs

### DIFF
--- a/cactus_test_definitions/client/procedures/STO-01.yaml
+++ b/cactus_test_definitions/client/procedures/STO-01.yaml
@@ -18,6 +18,7 @@ Criteria:
       parameters: { "minimum_count": 4 }
 
 Preconditions:
+  immediate_start: true  # There will be no "init" phase - all interactions will be immediately logged against the test
   init_actions:
     - type: set-comms-rate
       parameters:

--- a/cactus_test_definitions/client/procedures/STO-04.yaml
+++ b/cactus_test_definitions/client/procedures/STO-04.yaml
@@ -18,6 +18,7 @@ Criteria:
       parameters: { "minimum_count": 4 }
 
 Preconditions:
+  immediate_start: true  # There will be no "init" phase - all interactions will be immediately logged against the test
   init_actions:
     - type: set-comms-rate
       parameters:


### PR DESCRIPTION
Tests with immediate start are not able to be run as part of a playlist. Here this will preserve the assumption that no MUP exists on the server prior to the test.