### PR TITLE
Ruff

### DIFF
--- a/.github/workflows/linttest.yml
+++ b/.github/workflows/linttest.yml
@@ -7,59 +7,25 @@ on:
   workflow_dispatch:
 
 jobs:
-  bandit_py312:
+  ruff:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3.1.0
-
-      - name: Setup Python
-        uses: actions/setup-python@v4.2.0
-        with:
-          python-version: "3.12"
-
-      - name: Install Dependencies
-        run: |
-          pip install .[dev]
-
-      - name: Run bandit
-        run: |
-          bandit -r -c pyproject.toml .
-
-  flake8_py312:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3.1.0
-
-      - name: Setup Python
-        uses: actions/setup-python@v4.2.0
-        with:
-          python-version: "3.12"
-
-      - name: Setup flake8 annotations
-        uses: rbialon/flake8-annotations@v1
-
-      - name: Lint with flake8
-        if: always()
-        run: |
-          pip install flake8
-          flake8 . --count --statistics
-
-  black_formatting:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: psf/black@stable
+      - uses: actions/checkout@v4
+      - name: Install ruff
+        run: pip install ruff
+      - name: Lint
+        run: ruff check .
+      - name: Format check
+        run: ruff format --check .
 
   mypy_py312:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4.2.0
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
@@ -74,15 +40,14 @@ jobs:
         run: |
           mypy .
 
-  
   pytest_py312:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4.2.0
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
@@ -98,5 +63,3 @@ jobs:
         with:
           paths: .test_report.xml
         if: always()
-
-  

--- a/.github/workflows/linttest.yml
+++ b/.github/workflows/linttest.yml
@@ -1,4 +1,4 @@
-name: Linting and Testing
+name: CI
 on:
   push:
     branches: [main]
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  lint:
+  ruff_bandit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linttest.yml
+++ b/.github/workflows/linttest.yml
@@ -7,16 +7,18 @@ on:
   workflow_dispatch:
 
 jobs:
-  ruff:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install ruff
-        run: pip install ruff
-      - name: Lint
+      - name: Install linters
+        run: pip install ruff bandit
+      - name: Lint (ruff)
         run: ruff check .
       - name: Format check
         run: ruff format --check .
+      - name: Security scan (bandit)
+        run: bandit -r cactus_test_definitions/
 
   mypy_py312:
     runs-on: ubuntu-latest

--- a/cactus_test_definitions/client/actions.py
+++ b/cactus_test_definitions/client/actions.py
@@ -18,7 +18,7 @@ class Action:
     type: str
     parameters: dict[str, Any]
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Some parameter values might contain variable expressions (eg: a string "$now") that needs to be replaced
         with an parsed Expression object instead."""
         for k, v in self.parameters.items():

--- a/cactus_test_definitions/client/checks.py
+++ b/cactus_test_definitions/client/checks.py
@@ -24,7 +24,7 @@ class Check:
     type: str
     parameters: dict[str, Any]
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Some parameter values might contain variable expressions (eg: a string "$now") that needs to be replaced
         with an parsed Expression object instead."""
         for k, v in self.parameters.items():

--- a/cactus_test_definitions/client/events.py
+++ b/cactus_test_definitions/client/events.py
@@ -26,7 +26,7 @@ class Event:
     parameters: dict[str, Any]  # Any parameters to the event listener
     checks: list[Check] | None = None  # This event will be blocked from triggering if any of these checks return False
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Some parameter values might contain variable expressions (eg: a string "$now") that needs to be replaced
         with an parsed Expression object instead."""
         for k, v in self.parameters.items():

--- a/cactus_test_definitions/client/test_procedures.py
+++ b/cactus_test_definitions/client/test_procedures.py
@@ -3,12 +3,13 @@ from enum import StrEnum
 from importlib import resources
 
 import yaml
+from dataclass_wizard import LoadMeta, YAMLWizard
+
 from cactus_test_definitions.client.actions import Action
 from cactus_test_definitions.client.checks import Check
 from cactus_test_definitions.client.events import Event
 from cactus_test_definitions.csipaus import CSIPAusVersion
 from cactus_test_definitions.schema import UniqueKeyLoader
-from dataclass_wizard import LoadMeta, YAMLWizard
 
 
 class TestProcedureId(StrEnum):

--- a/cactus_test_definitions/client/test_procedures.py
+++ b/cactus_test_definitions/client/test_procedures.py
@@ -184,7 +184,7 @@ def get_yaml_contents(test_procedure_id: TestProcedureId) -> str:
     """Finds the YAML contents for the TestProcedure with the specified TestProcedureId"""
     yaml_resource = resources.files("cactus_test_definitions.client.procedures") / f"{test_procedure_id}.yaml"
     with resources.as_file(yaml_resource) as yaml_file:
-        with open(yaml_file, "r") as f:
+        with open(yaml_file) as f:
             yaml_contents = f.read()
             return yaml_contents
 

--- a/cactus_test_definitions/parameters.py
+++ b/cactus_test_definitions/parameters.py
@@ -42,7 +42,7 @@ class ParameterSchema:
     expected_type: ParameterType
 
 
-def is_valid_parameter_type(expected_type: ParameterType, value: Any) -> bool:
+def is_valid_parameter_type(expected_type: ParameterType, value: Any) -> bool:  # noqa: C901, ANN401
     """Returns true if the specified value "passes" as the expected type. Only performs rudimentary checks to try
     and catch obvious misconfigurations"""
     if value is None:

--- a/cactus_test_definitions/parameters.py
+++ b/cactus_test_definitions/parameters.py
@@ -73,9 +73,9 @@ def is_valid_parameter_type(expected_type: ParameterType, value: Any) -> bool:
         case ParameterType.DateTime:
             return isinstance(value, datetime)
         case ParameterType.ListString:
-            return isinstance(value, list) and all((isinstance(e, str) for e in value))
+            return isinstance(value, list) and all(isinstance(e, str) for e in value)
         case ParameterType.ListInteger:
-            return isinstance(value, list) and all((isinstance(e, int) for e in value))
+            return isinstance(value, list) and all(isinstance(e, int) for e in value)
         case ParameterType.HexBinary:
             try:
                 int(value, 16)
@@ -89,7 +89,7 @@ def is_valid_parameter_type(expected_type: ParameterType, value: Any) -> bool:
                 return False
         case ParameterType.ListCSIPAusResource:
             return isinstance(value, list) and all(
-                (is_valid_parameter_type(ParameterType.CSIPAusResource, e) for e in value)
+                is_valid_parameter_type(ParameterType.CSIPAusResource, e) for e in value
             )
         case ParameterType.CSIPAusReadingType:
             try:
@@ -98,7 +98,7 @@ def is_valid_parameter_type(expected_type: ParameterType, value: Any) -> bool:
                 return False
         case ParameterType.ListCSIPAusReadingType:
             return isinstance(value, list) and all(
-                (is_valid_parameter_type(ParameterType.CSIPAusReadingType, e) for e in value)
+                is_valid_parameter_type(ParameterType.CSIPAusReadingType, e) for e in value
             )
         case ParameterType.CSIPAusReadingLocation:
             try:
@@ -114,7 +114,7 @@ def is_valid_parameter_type(expected_type: ParameterType, value: Any) -> bool:
                 if (
                     not is_valid_parameter_type(ParameterType.CSIPAusReadingType, reading_type)
                     or not isinstance(reading_vals, list)
-                    or not all((is_valid_parameter_type(ParameterType.Float, rv) for rv in reading_vals))
+                    or not all(is_valid_parameter_type(ParameterType.Float, rv) for rv in reading_vals)
                 ):
                     return False
 

--- a/cactus_test_definitions/schema.py
+++ b/cactus_test_definitions/schema.py
@@ -12,7 +12,7 @@ class UniqueKeyLoader(yaml.SafeLoader):
         key1: def
     """
 
-    def construct_mapping(self, node, deep=False):
+    def construct_mapping(self, node: yaml.MappingNode, deep: bool = False) -> dict:
         mapping = set()
         for key_node, _ in node.value:
             key = self.construct_object(key_node, deep=deep)

--- a/cactus_test_definitions/server/actions.py
+++ b/cactus_test_definitions/server/actions.py
@@ -19,7 +19,7 @@ class Action:
     client: str | None = None  # use the client with this id to execute this action. If None, use the 0th client
     parameters: dict[str, Any] = None  # type: ignore # This will be forced in __post_init__
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Some parameter values might contain variable expressions (eg: a string "$now") that needs to be replaced
         with an parsed Expression object instead."""
         if self.parameters is None:

--- a/cactus_test_definitions/server/admin_instructions.py
+++ b/cactus_test_definitions/server/admin_instructions.py
@@ -16,7 +16,7 @@ class AdminInstruction:
     client: str | None = None  # The RequiredClient.id this instruction refers to. If None - applies to the 0th client
     parameters: dict[str, Any] = None  # type: ignore # Forced in __post_init__
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.parameters is None:
             self.parameters = {}
 

--- a/cactus_test_definitions/server/checks.py
+++ b/cactus_test_definitions/server/checks.py
@@ -23,7 +23,7 @@ class Check:
     type: str
     parameters: dict[str, Any] = None  # type: ignore # This will be forced in __post_init__
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Some parameter values might contain variable expressions (eg: a string "$now") that needs to be replaced
         with an parsed Expression object instead."""
         if self.parameters is None:

--- a/cactus_test_definitions/server/test_procedures.py
+++ b/cactus_test_definitions/server/test_procedures.py
@@ -3,12 +3,13 @@ from enum import StrEnum
 from importlib import resources
 
 import yaml
+from dataclass_wizard import LoadMeta, YAMLWizard
+
 from cactus_test_definitions.csipaus import CSIPAusVersion
 from cactus_test_definitions.schema import UniqueKeyLoader
 from cactus_test_definitions.server.actions import Action
 from cactus_test_definitions.server.admin_instructions import AdminInstruction
 from cactus_test_definitions.server.checks import Check
-from dataclass_wizard import LoadMeta, YAMLWizard
 
 
 class TestProcedureId(StrEnum):

--- a/cactus_test_definitions/server/test_procedures.py
+++ b/cactus_test_definitions/server/test_procedures.py
@@ -163,7 +163,7 @@ def get_yaml_contents(test_procedure_id: TestProcedureId) -> str:
     """Finds the YAML contents for the TestProcedure with the specified TestProcedureId"""
     yaml_resource = resources.files("cactus_test_definitions.server.procedures") / f"{test_procedure_id}.yaml"
     with resources.as_file(yaml_resource) as yaml_file:
-        with open(yaml_file, "r") as f:
+        with open(yaml_file) as f:
             yaml_contents = f.read()
             return yaml_contents
 

--- a/cactus_test_definitions/server/validate.py
+++ b/cactus_test_definitions/server/validate.py
@@ -14,7 +14,7 @@ def validate_test_procedure(test_procedure: TestProcedure, test_procedure_id: Te
         raise TestProcedureDefinitionError(
             f"{test_procedure_id} has no RequiredClients element. At least 1 entry required"
         )
-    required_clients_by_id = dict(((rc.id, rc) for rc in test_procedure.preconditions.required_clients))
+    required_clients_by_id = dict((rc.id, rc) for rc in test_procedure.preconditions.required_clients)
 
     for step in test_procedure.steps:
         validate_action_parameters(test_procedure_id, step.id, step.action)

--- a/cactus_test_definitions/server/validate.py
+++ b/cactus_test_definitions/server/validate.py
@@ -8,7 +8,7 @@ from cactus_test_definitions.server.test_procedures import (
 )
 
 
-def validate_test_procedure(test_procedure: TestProcedure, test_procedure_id: TestProcedureId):
+def validate_test_procedure(test_procedure: TestProcedure, test_procedure_id: TestProcedureId) -> None:
     # Check preconditions
     if not test_procedure.preconditions.required_clients:
         raise TestProcedureDefinitionError(

--- a/cactus_test_definitions/variable_expressions.py
+++ b/cactus_test_definitions/variable_expressions.py
@@ -129,7 +129,7 @@ def snake_to_camel(snake: str) -> str:
     return temp[0].lower() + temp[1:]
 
 
-def named_variable_repr(named_var: NamedVariableType) -> str:
+def named_variable_repr(named_var: NamedVariableType) -> str:  # noqa: C901
     """Takes named variable enum and turns its name into its recognisable 2030.5 form"""
     name = named_var.name
     if len(name.split("_")) == 1:
@@ -255,7 +255,7 @@ def parse_time_delta(var_body: str) -> timedelta:
         )
 
 
-def parse_unary_expression(token: Token) -> Constant | NamedVariable:
+def parse_unary_expression(token: Token) -> Constant | NamedVariable:  # noqa: C901
     """Parses a unary expression from a variable body"""
 
     if token.type == tokenize.NAME:
@@ -393,7 +393,7 @@ def parse_variable_expression_body(var_body: str, param_key: str | None) -> Name
         raise UnparseableVariableExpressionError(f"Unable to parse {var_body} into a simple binary/unary expression")
 
 
-def try_extract_variable_expression(body: Any) -> str | None:
+def try_extract_variable_expression(body: Any) -> str | None:  # noqa: ANN401
     """Checks to see if a variable body (of any type) can be parsed by parse_variable_expression_body. If it can,
     it will be returned as a string. Otherwise None will be returned
 
@@ -448,7 +448,7 @@ def try_extract_variable_expression(body: Any) -> str | None:
     return variable_expression
 
 
-def is_resolvable_variable(v: Any) -> bool:
+def is_resolvable_variable(v: Any) -> bool:  # noqa: ANN401
     """Returns True if the supplied value is a variable definition that requires resolving"""
     return isinstance(v, NamedVariable) or isinstance(v, Expression) or isinstance(v, Constant)
 

--- a/cactus_test_definitions/variable_expressions.py
+++ b/cactus_test_definitions/variable_expressions.py
@@ -236,10 +236,10 @@ def parse_time_delta(var_body: str) -> timedelta:
 
     try:
         number = float(number_string)
-    except ValueError:
+    except ValueError as err:
         raise UnparseableVariableExpressionError(
             f"{var_body} can't be parsed into a timedelta. Bad number {number_string}"
-        )
+        ) from err
 
     if time_unit_string in {"day", "days"}:
         return timedelta(days=number)
@@ -328,8 +328,8 @@ def parse_unary_expression(token: Token) -> Constant | NamedVariable:
                 return Constant(float(token.string))
             else:
                 return Constant(int(token.string))
-    except ValueError:
-        raise UnparseableVariableExpressionError(f"'{token.string}' can't be converted to a number")
+    except ValueError as err:
+        raise UnparseableVariableExpressionError(f"'{token.string}' can't be converted to a number") from err
 
     if token.type == tokenize.STRING:
         return Constant(parse_time_delta(token.string))
@@ -382,8 +382,8 @@ def parse_variable_expression_body(var_body: str, param_key: str | None) -> Name
             for t in tokenize.generate_tokens(StringIO(var_body).readline)
             if t.type in {tokenize.NUMBER, tokenize.OP, tokenize.STRING, tokenize.NAME}
         ]
-    except tokenize.TokenError as exc:
-        raise UnparseableVariableExpressionError(f"Error tokenizing '{var_body}': {exc}")
+    except tokenize.TokenError as err:
+        raise UnparseableVariableExpressionError(f"Error tokenizing '{var_body}'") from err
 
     if len(var_tokens) == 1:
         return parse_unary_expression(var_tokens[0])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,13 +59,13 @@ testpaths = ["tests"]
 line-length = 120
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "I", "S", "C90", "B"]
+select = ["E", "W", "F", "I", "S", "C90", "B", "UP", "ANN", "N"]
 
 [tool.ruff.lint.mccabe]
-max-complexity = 15
+max-complexity = 10
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["S"]
+"tests/**" = ["S", "ANN"]
 
 [tool.mypy]
 exclude = ["dist", "build", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ select = ["E", "W", "F", "I", "S", "C90", "B", "UP", "ANN", "N"]
 max-complexity = 10
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["S", "ANN"]
+"tests/**" = ["S", "ANN", "N"]
 
 [tool.mypy]
 exclude = ["dist", "build", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,12 +40,8 @@ Changelog = "https://github.com/bsgip/cactus-test-definitions/blob/main/CHANGELO
 
 [project.optional-dependencies]
 dev = [
-  "bandit",
-  "black",
-  "flake8",
-  "isort",
-  "mccabe",
   "mypy",
+  "ruff",
   "tox",
   "python-dotenv[cli]",
   "types-PyYAML",
@@ -59,15 +55,17 @@ addopts = "-ra -q"
 testpaths = ["tests"]
 
 
-[tool.black]
+[tool.ruff]
 line-length = 120
 
-[tool.isort]
-profile = "black"
-src_paths = ["src", "tests"]
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "S", "C90", "B"]
 
-[tool.bandit]
-exclude_dirs = ["tests"]
+[tool.ruff.lint.mccabe]
+max-complexity = 15
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S"]
 
 [tool.mypy]
 exclude = ["dist", "build", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ Changelog = "https://github.com/bsgip/cactus-test-definitions/blob/main/CHANGELO
 
 [project.optional-dependencies]
 dev = [
+  "bandit",
   "mypy",
   "ruff",
   "tox",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,15 +1,3 @@
-[flake8]
-max-line-length = 120
-max-complexity = 10
-exclude = dist/
-
-[isort]
-force_grid_wrap = 0
-include_trailing_comma = True
-line_length = 120
-multi_line_output = 3
-use_parentheses = True
-
 [options]
 packages = find:
 

--- a/tests/unit/client/test_actions.py
+++ b/tests/unit/client/test_actions.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import pytest
+
 from cactus_test_definitions import variable_expressions as varexps
 from cactus_test_definitions.client.actions import (
     Action,

--- a/tests/unit/client/test_checks.py
+++ b/tests/unit/client/test_checks.py
@@ -1,4 +1,5 @@
 import pytest
+
 from cactus_test_definitions import variable_expressions as varexps
 from cactus_test_definitions.client.checks import Check, validate_check_parameters
 from cactus_test_definitions.errors import TestProcedureDefinitionError

--- a/tests/unit/client/test_events.py
+++ b/tests/unit/client/test_events.py
@@ -1,4 +1,5 @@
 import pytest
+
 from cactus_test_definitions import variable_expressions as varexps
 from cactus_test_definitions.client.events import Event, validate_event_parameters
 from cactus_test_definitions.errors import TestProcedureDefinitionError

--- a/tests/unit/client/test_test_procedures.py
+++ b/tests/unit/client/test_test_procedures.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from importlib import resources
 from pathlib import Path
 
@@ -52,7 +52,7 @@ def test_available_tests_populated():
 def test_error_on_duplicate_key():
     """Force test procedures to load and ensure they all validate (and we at least have a few)"""
 
-    with open(Path("tests/data/client/tp_error_duplicate_keys.yaml"), "r") as fp:
+    with open(Path("tests/data/client/tp_error_duplicate_keys.yaml")) as fp:
         yaml_contents = fp.read()
 
     with pytest.raises(ValueError):
@@ -62,7 +62,7 @@ def test_error_on_duplicate_key():
 def test_error_on_extra_key():
     """Force test procedures to load and ensure they all validate (and we at least have a few)"""
 
-    with open(Path("tests/data/client/tp_error_extra_keys.yaml"), "r") as fp:
+    with open(Path("tests/data/client/tp_error_extra_keys.yaml")) as fp:
         yaml_contents = fp.read()
 
     with pytest.raises(UnknownKeysError):
@@ -72,7 +72,7 @@ def test_error_on_extra_key():
 def test_TestProcedures_action_parameter_types():
     """Tests that lists/dicts/constants/datetimes can all be encoded/decoded via the yaml action definition"""
 
-    with open(Path("tests/data/client/tp_action_parameters.yaml"), "r") as fp:
+    with open(Path("tests/data/client/tp_action_parameters.yaml")) as fp:
         tp = parse_test_procedure(fp.read())
 
     step = tp.steps["Step-1"]
@@ -85,13 +85,13 @@ def test_TestProcedures_action_parameter_types():
             11,
             2.2,
             "List Item 3",
-            datetime(2020, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+            datetime(2020, 1, 2, 3, 4, 5, tzinfo=UTC),
         ],
         "param_dict_str": {"key1": "value1", "key2": "value2"},
         "param_dict_int": {"key11": 11, "key22": 22},
         "param_int": 11,
         "param_str": "Value 11",
-        "param_datetime_utc": datetime(2025, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        "param_datetime_utc": datetime(2025, 1, 2, 3, 4, 5, tzinfo=UTC),
         "param_datetime_naive": datetime(2025, 1, 2, 3, 4, 5, tzinfo=None),
         "param_with_variable_date": NamedVariable(NamedVariableType.NOW),
         "param_with_variable_db_lookup": NamedVariable(NamedVariableType.DERSETTING_SET_MAX_W),

--- a/tests/unit/client/test_test_procedures.py
+++ b/tests/unit/client/test_test_procedures.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 from assertical.asserts.type import assert_dict_type
+from dataclass_wizard.errors import UnknownKeysError
+
 from cactus_test_definitions.client.test_procedures import (
     TestProcedure,
     TestProcedureId,
@@ -17,7 +19,6 @@ from cactus_test_definitions.variable_expressions import (
     NamedVariableType,
     OperationType,
 )
-from dataclass_wizard.errors import UnknownKeysError
 
 
 def test_TestProcedureId_synchronised():

--- a/tests/unit/client/test_validate.py
+++ b/tests/unit/client/test_validate.py
@@ -86,7 +86,7 @@ def collect_check_param_values(tp: TestProcedure, check_type: str, param_name: s
     ],
 )
 def test_TestProcedure_invalid_examples(tp_file: Path):
-    with open(tp_file, "r") as fp:
+    with open(tp_file) as fp:
         tp = parse_test_procedure(fp.read())
 
     with pytest.raises(TestProcedureDefinitionError):

--- a/tests/unit/client/test_validate.py
+++ b/tests/unit/client/test_validate.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+
 from cactus_test_definitions.client.actions import ACTION_PARAMETER_SCHEMA, Action
 from cactus_test_definitions.client.checks import CHECK_PARAMETER_SCHEMA, Check
 from cactus_test_definitions.client.test_procedures import (
@@ -146,16 +147,16 @@ def test_each_step_accessible(tp_id: TestProcedureId):  # noqa: C901
     # Each test should be added once and removed once
     for step_name in step_names:
         if step_name not in ignored_steps:
-            assert (
-                removal_count[step_name] == 1
-            ), f"{step_name}: Each test should be removed once otherwise the test cannot complete"
+            assert removal_count[step_name] == 1, (
+                f"{step_name}: Each test should be removed once otherwise the test cannot complete"
+            )
 
         if step_name == first_step:
             assert enabled_count[step_name] == 0, f"{step_name}: The first test step is already enabled"
         else:
-            assert (
-                enabled_count[step_name] == 1
-            ), f"{step_name}: Each test should be added once - not expecting loops of steps"
+            assert enabled_count[step_name] == 1, (
+                f"{step_name}: Each test should be added once - not expecting loops of steps"
+            )
 
 
 @pytest.mark.parametrize("tp_id", TestProcedureId)
@@ -191,9 +192,9 @@ def test_each_step_connected(tp_id: TestProcedureId):
         for n in [name for a in tp.preconditions.actions if a.type == "enable-steps" for name in a.parameters["steps"]]:
             visited_nodes.add(n)
 
-    assert (
-        step_names == visited_nodes
-    ), "Missing entries here indicate a step (or steps) that can't be reached from the root node"
+    assert step_names == visited_nodes, (
+        "Missing entries here indicate a step (or steps) that can't be reached from the root node"
+    )
 
 
 @pytest.mark.parametrize("tp_id", TestProcedureId)

--- a/tests/unit/server/test_admin_instructions.py
+++ b/tests/unit/server/test_admin_instructions.py
@@ -1,7 +1,8 @@
 import pytest
+
+from cactus_test_definitions.errors import TestProcedureDefinitionError
 from cactus_test_definitions.server.test_procedures import TestProcedureId, parse_test_procedure
 from cactus_test_definitions.server.validate import validate_test_procedure
-from cactus_test_definitions.errors import TestProcedureDefinitionError
 from cactus_test_definitions.variable_expressions import Expression
 
 # Minimal valid YAML mirroring S-ALL-21 precondition, with admin_instructions added

--- a/tests/unit/server/test_test_procedures.py
+++ b/tests/unit/server/test_test_procedures.py
@@ -3,13 +3,14 @@ from pathlib import Path
 
 import pytest
 from assertical.asserts.type import assert_dict_type
+from dataclass_wizard.errors import UnknownKeysError
+
 from cactus_test_definitions.server.test_procedures import (
     TestProcedure,
     TestProcedureId,
     get_all_test_procedures,
     parse_test_procedure,
 )
-from dataclass_wizard.errors import UnknownKeysError
 
 
 def test_TestProcedureId_synchronised():

--- a/tests/unit/server/test_test_procedures.py
+++ b/tests/unit/server/test_test_procedures.py
@@ -44,7 +44,7 @@ def test_available_tests_populated():
 def test_error_on_duplicate_key():
     """Force test procedures to load and ensure they all validate (and we at least have a few)"""
 
-    with open(Path("tests/data/server/tp_error_duplicate_keys.yaml"), "r") as fp:
+    with open(Path("tests/data/server/tp_error_duplicate_keys.yaml")) as fp:
         yaml_contents = fp.read()
 
     with pytest.raises(ValueError):
@@ -54,7 +54,7 @@ def test_error_on_duplicate_key():
 def test_error_on_extra_key():
     """Force test procedures to load and ensure they all validate (and we at least have a few)"""
 
-    with open(Path("tests/data/server/tp_error_extra_keys.yaml"), "r") as fp:
+    with open(Path("tests/data/server/tp_error_extra_keys.yaml")) as fp:
         yaml_contents = fp.read()
 
     with pytest.raises(UnknownKeysError):

--- a/tests/unit/server/test_validate.py
+++ b/tests/unit/server/test_validate.py
@@ -22,7 +22,7 @@ def test_each_step_id_unique(tp_id: TestProcedureId):
     tp = get_test_procedure(tp_id)
     all_ids = [s.id for s in tp.steps]
     assert list(sorted(all_ids)) == list(sorted(set(all_ids)))
-    assert len(set((s.id for s in tp.steps))) == len(tp.steps), "All steps must have a unique id property"
+    assert len(set(s.id for s in tp.steps)) == len(tp.steps), "All steps must have a unique id property"
 
 
 @pytest.mark.parametrize("tp_id", TestProcedureId)

--- a/tests/unit/server/test_validate.py
+++ b/tests/unit/server/test_validate.py
@@ -1,4 +1,5 @@
 import pytest
+
 from cactus_test_definitions.server.actions import ACTION_PARAMETER_SCHEMA
 from cactus_test_definitions.server.test_procedures import (
     TestProcedureId,
@@ -36,9 +37,9 @@ def test_each_alias_defined(tp_id: str):
     CREATE_SUB_ACTION = "create-subscription"
     DELETE_SUB_ACTION = "delete-subscription"
     assert UPSERT_MUP_ACTION in ACTION_PARAMETER_SCHEMA, "If this fails - the action name has changed. Update this test"
-    assert (
-        INSERT_READING_ACTION in ACTION_PARAMETER_SCHEMA
-    ), "If this fails - the action name has changed. Update this test"
+    assert INSERT_READING_ACTION in ACTION_PARAMETER_SCHEMA, (
+        "If this fails - the action name has changed. Update this test"
+    )
     assert CREATE_SUB_ACTION in ACTION_PARAMETER_SCHEMA, "If this fails - the action name has changed. Update this test"
     assert DELETE_SUB_ACTION in ACTION_PARAMETER_SCHEMA, "If this fails - the action name has changed. Update this test"
 

--- a/tests/unit/test_csipaus.py
+++ b/tests/unit/test_csipaus.py
@@ -1,4 +1,5 @@
 import pytest
+
 from cactus_test_definitions.csipaus import (
     CSIPAusReadingLocation,
     CSIPAusReadingType,

--- a/tests/unit/test_parameters.py
+++ b/tests/unit/test_parameters.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from decimal import Decimal
 from itertools import product
 from typing import Any
@@ -65,7 +65,7 @@ def test_is_valid_parameter_type_skipped_values(value: Any, type: ParameterType)
         (ParameterType.Integer, [2], False),
         (ParameterType.Integer, "2", False),
         (ParameterType.DateTime, datetime(2022, 11, 1, 1, 2, 3), True),
-        (ParameterType.DateTime, datetime(2022, 11, 1, 1, 2, 3, tzinfo=timezone.utc), True),
+        (ParameterType.DateTime, datetime(2022, 11, 1, 1, 2, 3, tzinfo=UTC), True),
         (ParameterType.DateTime, "2022-11-01T01:02:03Z", False),
         (ParameterType.DateTime, "2022-11-01T01:02:03", False),
         (ParameterType.DateTime, 2022, False),

--- a/tests/unit/test_parameters.py
+++ b/tests/unit/test_parameters.py
@@ -4,6 +4,7 @@ from itertools import product
 from typing import Any
 
 import pytest
+
 from cactus_test_definitions.errors import TestProcedureDefinitionError
 from cactus_test_definitions.parameters import (
     ParameterSchema,

--- a/tests/unit/test_variable_expressions.py
+++ b/tests/unit/test_variable_expressions.py
@@ -3,8 +3,10 @@ from decimal import Decimal
 from typing import Any
 
 import pytest
+
 from cactus_test_definitions.client.test_procedures import Action
 from cactus_test_definitions.variable_expressions import (
+    BaseExpression,
     Constant,
     Expression,
     NamedVariable,
@@ -13,13 +15,12 @@ from cactus_test_definitions.variable_expressions import (
     UnparseableVariableExpressionError,
     has_named_variable,
     is_resolvable_variable,
-    parse_time_delta,
-    parse_variable_expression_body,
-    try_extract_variable_expression,
-    snake_to_camel,
     named_variable_repr,
     operation_repr,
-    BaseExpression,
+    parse_time_delta,
+    parse_variable_expression_body,
+    snake_to_camel,
+    try_extract_variable_expression,
 )
 
 


### PR DESCRIPTION
Will copy paste these PR notes across the PR's and specifically flag anything truly odd if needed.

Replace black, isort, flake8, flake8-bugbear, and mccabe with ruff.

Key config choices: 
- Rules: E, W, F, I, S, C90, B, UP, ANN, N: equivalent to the old toolchain plus pyupgrade (UP) and type annotation enforcement (ANN), and N (naming conventions).
- max-complexity = 10. Overly complex functions get # noqa: C901 rather than being refactored.
- raise ... from err: enforced (B904). Where the original exception is already logged with exc_info=, I use from None to avoid a redundant chained traceback.

Some config suppressed in tests for simplicity.