### PR TITLE
remove proceed - back to wait

### DIFF
--- a/cactus_test_definitions/client/procedures/GEN-10.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-10.yaml
@@ -1012,11 +1012,10 @@ Steps:
   WAIT-OBSERVE-DERP-1-6-DEFAULTS:
     instructions:
       - The device should ramp to DERP 1 DefaultDERControl opModExpLimW = 50% (as per TS 5573 [ee])
-      - Click Proceed AFTER the DER is exporting at the correct limit. 
     event:
-      type: proceed
+      type: wait
       parameters:
-        timeout_seconds: 300 # End test after 5 mins if proceed not pressed
+        duration_seconds: 300
     actions:
       - type: remove-steps
         parameters:

--- a/cactus_test_definitions/client/procedures/GEN-13.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-13.yaml
@@ -63,28 +63,11 @@ Steps:
     event:
       type: wait
       parameters:
-        duration_seconds: 360
+        duration_seconds: 500
     actions:
       - type: remove-steps
         parameters:
           steps:
             - WAIT-TEST-END
-      - type: enable-steps
-        parameters:
-          steps:
-            - FINISH-TEST
-
-  FINISH-TEST:
-    instructions:
-      - AFTER the last DERControl is correctly adhered to, click proceed to end the test.
-    event:
-        type: proceed
-        parameters:
-          timeout_seconds: 180 # End test after 3 mins if proceed not pressed
-    actions:
-      - type: remove-steps
-        parameters:
-          steps:
-            - FINISH-TEST
       - type: finish-test
         parameters: {}

--- a/cactus_test_definitions/client/procedures/LOA-10.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-10.yaml
@@ -1012,11 +1012,10 @@ Steps:
   WAIT-OBSERVE-DERP-1-6-DEFAULTS:
     instructions:
       - The device should ramp to DERP 1 DefaultDERControl opModImpLimW = 50% (as per TS 5573 [ee])
-      - Click Proceed AFTER the DER is importing at the correct limit. 
     event:
-      type: proceed
+      type: wait
       parameters:
-        timeout_seconds: 300 # End test after 5 mins if proceed not pressed
+        duration_seconds: 300
     actions:
       - type: remove-steps
         parameters:

--- a/cactus_test_definitions/client/procedures/LOA-13.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-13.yaml
@@ -64,28 +64,11 @@ Steps:
     event:
       type: wait
       parameters:
-        duration_seconds: 360
+        duration_seconds: 500
     actions:
       - type: remove-steps
         parameters:
           steps:
             - WAIT-TEST-END
-      - type: enable-steps
-        parameters:
-          steps:
-              - FINISH-TEST
-
-  FINISH-TEST:
-    instructions: 
-      - AFTER the last DERControl is correctly adhered to, click proceed to end the test.
-    event:
-        type: proceed
-        parameters:
-          timeout_seconds: 180 # End test after 3 mins if proceed not pressed
-    actions:
-      - type: remove-steps
-        parameters:
-          steps:
-            - FINISH-TEST
       - type: finish-test
         parameters: {}


### PR DESCRIPTION
Clients failing witness tests due to not reading instructions - cost to witness test team for repeated test. Reverting to wait times.