### PR TITLE
Add alternate ALL-29 and LOA-13 variants for EVSE witness testing

### DIFF
--- a/cactus_test_definitions/client/procedures/ALT-ALL-29.yaml
+++ b/cactus_test_definitions/client/procedures/ALT-ALL-29.yaml
@@ -1,0 +1,90 @@
+Description: Validate Operating Telemetry (EVSE Alternate - import limits increased by 20%)
+Category: DER
+Classes:
+  - DER-A
+
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+  - v1.3
+
+Criteria:
+  checks:
+    - type: all-steps-complete
+      parameters: {}
+
+    # Test is ~10 minutes of waiting which should leave enough time for at least 8 reading posts
+    - type: readings-site-active-power
+      parameters: {"minimum_count": 8} 
+    - type: readings-der-active-power
+      parameters: {"minimum_count": 8}
+
+Preconditions:
+  init_actions:
+    - type: set-comms-rate
+      parameters:
+        dcap_poll_seconds: 60
+        edev_list_poll_seconds: 60
+        fsa_list_poll_seconds: 60
+        der_list_poll_seconds: 60
+        derp_list_poll_seconds: 60
+        mup_post_seconds: 60
+  checks:
+    - type: end-device-contents
+      parameters: {}
+    - type: der-settings-contents
+      parameters: {}
+  actions:
+    - type: create-der-control
+      parameters:
+        start: $(now)
+        duration_seconds: 120
+        opModExpLimW: $(setMaxW * 2)
+        opModImpLimW: $(setMaxW * 2)
+        tag: DERC1
+    - type: create-der-control
+      parameters:
+        start: $(now + '2 minutes')
+        duration_seconds: 120
+        opModExpLimW: $(setMaxW * 0.5)
+        opModImpLimW: $(setMaxW * 0.5)
+        tag: DERC2
+    - type: create-der-control
+      parameters:
+        start: $(now + '4 minutes')
+        duration_seconds: 120
+        opModExpLimW: $(setMaxW * 0.4)
+        opModImpLimW: $(setMaxW * 0.4)
+        tag: DERC3
+    - type: create-der-control
+      parameters:
+        start: $(now + '6 minutes')
+        duration_seconds: 120
+        opModExpLimW: $(setMaxW * 0.3)
+        opModImpLimW: $(setMaxW * 0.3)
+        tag: DERC4
+    - type: create-der-control
+      parameters:
+        start: $(now + '8 minutes')
+        duration_seconds: 120
+        opModExpLimW: 0
+        opModImpLimW: 0
+        tag: DERC5
+  instructions:
+    - DER is operating at least 50% if its rated power.
+    - Connect a test load electrically in parallel with the DER.
+    - Set the load to consume 10% of the DER's rated active power.
+
+Steps:
+  WAIT-TEST-END:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 600 # Wait 10 mins to ensure 5th control has at least 2 mins active
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-TEST-END
+      - type: finish-test
+        parameters: {}

--- a/cactus_test_definitions/client/procedures/ALT-ALL-29.yaml
+++ b/cactus_test_definitions/client/procedures/ALT-ALL-29.yaml
@@ -1,7 +1,7 @@
 Description: Validate Operating Telemetry (EVSE Alternate - import limits increased by 20%)
 Category: DER
 Classes:
-  - DER-A
+  - DER-A-ALT
 
 TargetVersions:
   - v1.2

--- a/cactus_test_definitions/client/procedures/ALT-LOA-13.yaml
+++ b/cactus_test_definitions/client/procedures/ALT-LOA-13.yaml
@@ -1,7 +1,7 @@
 Description: Tracking import-limit through variable load (EVSE Alternate - import limit increased by 20%)
 Category: DER
 Classes:
-  - DER-L
+  - DER-L-ALT
 
 TargetVersions:
   - v1.2

--- a/cactus_test_definitions/client/procedures/ALT-LOA-13.yaml
+++ b/cactus_test_definitions/client/procedures/ALT-LOA-13.yaml
@@ -1,0 +1,74 @@
+Description: Tracking import-limit through variable load (EVSE Alternate - import limit increased by 20%)
+Category: DER
+Classes:
+  - DER-L
+
+TargetVersions:
+  - v1.2
+  - v1.3-beta/storage
+  - v1.3
+
+Criteria:
+  checks:
+    - type: all-steps-complete
+      parameters: {}
+
+Preconditions:
+  init_actions:
+    - type: set-comms-rate
+      parameters:
+        dcap_poll_seconds: 60
+        edev_list_poll_seconds: 60
+        fsa_list_poll_seconds: 60
+        der_list_poll_seconds: 60 
+        derp_list_poll_seconds: 60
+        mup_post_seconds: 60
+
+  checks:
+    - type: end-device-contents
+      parameters: {}
+    - type: der-settings-contents
+      parameters: {}
+  actions:
+    - type: create-der-control
+      parameters:
+        start: $(now)
+        duration_seconds: 60
+        opModImpLimW: $(setMaxW * 2)
+        tag: DERC1
+    - type: create-der-control
+      parameters:
+        start: $(now + '1 minute')
+        duration_seconds: 420
+        opModImpLimW: $(setMaxW * 0.4)
+        tag: DERC2
+  instructions:
+    - Connect a test load electrically in parallel with the DER.
+    - Set the load to consume 0W.
+
+Steps:
+
+  # This test is purely following a sequence of DERControls. It's expected that the following events occurs out of band:
+  # at t=0 - Test load is consuming 0W
+  # at t=120s - Test load is consuming 20% of setMaxW
+  # at t=240s - Test load is consuming 10% of setMaxW
+  # at t=360s - Test load is consuming 0W
+  #
+  # Validation MUST be performed by power meter to ensure that the DER is adjusting its power in response to changing 
+  # loads
+  WAIT-TEST-END:
+    instructions:
+      - At t=120s, set the load to consume 20% of the DER's rated active power.
+      - At t=240s, set the load to consume 10% of the DER's rated active power.
+      - At t=360s, set the load to consume 0W.
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 500
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-TEST-END
+      - type: finish-test
+        parameters: {}

--- a/cactus_test_definitions/client/test_procedures.py
+++ b/cactus_test_definitions/client/test_procedures.py
@@ -89,6 +89,10 @@ class TestProcedureId(StrEnum):
     P_01 = "P-01"
     P_02 = "P-02"
 
+    # Alternate tests
+    ALT_ALL_29 = "ALT-ALL-29"
+    ALT_LOA_13 = "ALT-LOA-13"
+
     # Storage extension
     STO_01 = "STO-01"
     STO_02 = "STO-02"


### PR DESCRIPTION
### Background

During the planning of EVSE witness testing, we identified that two test procedures (ALL-29 and LOA-13) cannot be executed properly due to the EV's inability to charge below 20% of its rated power. This results in the transitions between 0% and 10% in these two tests being indistinguishable.

To address this, we proposed minimal changes to these tests to accommodate EVSE technical constraints. The changes are as follows:

- **ALL-29:** increased the import limit values (`DERC2`, `DERC3`, `DERC4`) 
    from 30% → 20% → 10% → 0% 
    to 50% → 40% → 30% → 0%
- **LOA-13:** increased import limit (`DERC2`) from 20% to 40%.

These changes allow the EVSE to import above 20% of rated power and ensure that transitions between DERControls are observable during witness testing.

### Approval

This accommodation was discussed with CIRG on 21 May 2026 and approved for implementation.

### Related documentation

A detailed description of EVSE compliance expectations can be found at:
https://app.clickup.com/6964607/v/dc/6mhbz-16816