### PR TITLE
move derc creation until after reconnection

### DIFF
--- a/cactus_test_definitions/client/procedures/ALL-30.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-30.yaml
@@ -115,15 +115,8 @@ Steps:
     event:
       type: wait
       parameters:
-        duration_seconds: 240 # Give the user time to power off the device (needs to happen before DER control sends)
+        duration_seconds: 60 # Give the user time to power off the device
     actions:
-      - type: create-der-control
-        parameters:
-          start: $(now)
-          duration_seconds: 900
-          opModExpLimW: $(maxExportW * 0.5)
-          opModImpLimW: $(maxImportW * 0.5)
-          tag: DERC1
       - type: enable-steps
         parameters:
           steps:
@@ -142,6 +135,13 @@ Steps:
       type: proceed
       parameters: {}
     actions:
+      - type: create-der-control # Create this control after connection re-established. This avoids notifications being sent to the client during the disconnection.
+        parameters:
+          start: $(now - '60 seconds')
+          duration_seconds: 900
+          opModExpLimW: $(maxExportW * 0.5)
+          opModImpLimW: $(maxImportW * 0.5)
+          tag: DERC1
       - type: communications-status
         parameters:
           enabled: true
@@ -154,7 +154,6 @@ Steps:
         parameters:
           steps:
             - REESTABLISH-COMMUNICATION
-
 
   # (e)
   POLL-DERC-1:
@@ -186,4 +185,3 @@ Steps:
         parameters:
           steps:
             - POST-RESPONSE-STARTED
-    

--- a/cactus_test_definitions/client/procedures/ALL-30.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-30.yaml
@@ -115,7 +115,7 @@ Steps:
     event:
       type: wait
       parameters:
-        duration_seconds: 60 # Give the user time to power off the device
+        duration_seconds: 30 # Give the user time to power off the device
     actions:
       - type: enable-steps
         parameters:


### PR DESCRIPTION
Devices with subscriptions may have received DERC1 too early, leading them to respond with started before the connection to server is re-established (resulting in 500 responses). The device also may have started moving to the higher control too early in the test. 

Doing this allows us to reduce the wait time of the disconnect step as we are no longer needing clients to turn the device off before the control gets created