### PR TITLE
fix(server): S-ALL-05 final step now EndDevice resource

### DIFF
--- a/cactus_test_definitions/server/procedures/S-ALL-05.yaml
+++ b/cactus_test_definitions/server/procedures/S-ALL-05.yaml
@@ -171,5 +171,5 @@ Steps:
     action:
       type: refresh-resource
       parameters:
-        resource: EndDeviceList
+        resource: EndDevice
         expect_rejection_or_empty: true


### PR DESCRIPTION
Previously it was `EndDeviceList` however the wording of the step in the test procedures, 
```text
The client attempts to access the EndDeviceListLink endpoint for the EndDevice that was previously managed by the client.
```
Suggests to me that the EndDevice itself must be attempted to be accessed.
It also might conflict with the requirement that `EndDeviceList` is accessable prior to device registration as part of `S-ALL-02`. I'm not sure on that one.

Alternatively it would be good to have this step not be a part of this test, since all other steps are just so gosh darn useful in regression testing. This step, not so much. 