### PR TITLE
Add default der controls pt2

### DIFF
--- a/cactus_test_definitions/client/procedures/ALL-06.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-06.yaml
@@ -37,6 +37,13 @@ Preconditions:
         der_list_poll_seconds: 60
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
+    - type: set-default-der-control
+      parameters:
+      # The import and export values are specified as 0 in TS5573 Table 12.4.4. They have been altered for this test so
+      # that a device can see the difference when the active control is set to 0.
+        opModImpLimW: 100 
+        opModExpLimW: 100
+        setGradW: 27
   instructions:
     - Connect a test load electrically in parallel with the DER.
     - Set the load to consume 25% of the DER's rated active power.

--- a/cactus_test_definitions/client/procedures/ALL-06.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-06.yaml
@@ -37,6 +37,9 @@ Preconditions:
         der_list_poll_seconds: 60
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
+    - type: create-der-program
+      parameters:
+        primacy: 0
     - type: set-default-der-control
       parameters:
       # The import and export values are specified as 0 in TS5573 Table 12.4.4. They have been altered for this test so

--- a/cactus_test_definitions/client/procedures/ALL-06.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-06.yaml
@@ -41,7 +41,7 @@ Preconditions:
       parameters:
       # The import and export values are specified as 0 in TS5573 Table 12.4.4. They have been altered for this test so
       # that a device can see the difference when the active control is set to 0.
-        opModImpLimW: 100 
+        opModImpLimW: 100
         opModExpLimW: 100
         setGradW: 27
   instructions:

--- a/cactus_test_definitions/client/procedures/ALL-08.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-08.yaml
@@ -23,6 +23,9 @@ Preconditions:
         der_list_poll_seconds: 60
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
+    - type: create-der-program
+      parameters:
+        primacy: 0
     - type: set-default-der-control
       parameters:
       # The import and export values are specified as 0 in TS5573 Table 12.4.4. These have been altered for this test so

--- a/cactus_test_definitions/client/procedures/ALL-08.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-08.yaml
@@ -23,6 +23,13 @@ Preconditions:
         der_list_poll_seconds: 60
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
+    - type: set-default-der-control
+      parameters:
+      # The import and export values are specified as 0 in TS5573 Table 12.4.4. These have been altered for this test so
+      # that a device can resume generation/consumption and post the appropriate opModStatus value (step e).
+        opModImpLimW: 100 
+        opModExpLimW: 100
+        setGradW: 27
   checks:
     - type: end-device-contents
       parameters: {}

--- a/cactus_test_definitions/client/procedures/ALL-18.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-18.yaml
@@ -40,8 +40,8 @@ Preconditions:
         tag: DERC1
         start: $(now)
         duration_seconds: 120
-        opModExpLimW: $(setMaxW * 2) # Tests asks for a control of 200% at the start
-        opModImpLimW: $(setMaxW * 2)
+        opModExpLimW: $(maxExportW * 2)
+        opModImpLimW: $(maxImportW * 2)
     - type: create-der-program
       parameters:         
         primacy: 0

--- a/cactus_test_definitions/client/procedures/GEN-04.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-04.yaml
@@ -33,7 +33,7 @@ Preconditions:
       # that a device can follow the generation limits set in this test without being overridden.
         opModImpLimW: 100
         opModExpLimW: 100
-        setGradW: 27
+        setGradW: 167 # Increased from 27 in Table 12.4.4 to avoid two 13 minute waits without altering the test intent
   checks:
     - type: end-device-contents
       parameters: {}
@@ -91,11 +91,11 @@ Steps:
 
   WAIT-RAMP-DEFAULT-DERC:
     instructions:
-    - DER should ramp down generation to 30% at the rate of setGradW (default 0.27%/s)
+    - DER should ramp down generation to 30% at the rate of setGradW
     event:
       type: wait
       parameters:
-        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
+        duration_seconds: 120 # Ramp from 200 to 30% at 100%/min = 2 minutes
     actions:
       - type: enable-steps
         parameters:
@@ -128,10 +128,10 @@ Steps:
           steps:
             - GET-DERC-2
       
-  # (f, g) Waits for the new control to finish (with a bit of overtime)
+  # (f, g) Waits for the new control to finish
   WAIT-CONTROL-END:
     instructions:
-    - DER should discover a new control and then ramp up to unconstrained at the rate of setGradW (default 0.27%/s)
+    - DER should discover a new control and then ramp up to unconstrained at the rate of setGradW
     event:
       type: wait
       parameters:
@@ -148,11 +148,11 @@ Steps:
 
   WAIT-RAMP-DEFAULT-DERC-2:
     instructions:
-    - DER should ramp down generation to 30% at the rate of setGradW (default 0.27%/s)
+    - DER should ramp down generation to 30% at the rate of setGradW
     event:
       type: wait
       parameters:
-        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
+        duration_seconds: 120 # Ramp from 200 to 30% at 100%/min = 2 minutes
     actions:
       - type: enable-steps
         parameters:
@@ -191,7 +191,7 @@ Steps:
     event:
       type: wait
       parameters:
-        duration_seconds: 120 # The device should ramp from 30% to 0 at 16%/min
+        duration_seconds: 60 # The device should ramp from 30% to 0
     actions:
       - type: remove-steps
         parameters:
@@ -200,4 +200,4 @@ Steps:
       - type: finish-test
         parameters: {}
     instructions:
-    - DER shall ramp down generation to 0W at the rate of setGradW (default 0.27%/s)
+    - DER shall ramp down generation to 0W at the rate of setGradW

--- a/cactus_test_definitions/client/procedures/GEN-04.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-04.yaml
@@ -24,10 +24,13 @@ Preconditions:
         der_list_poll_seconds: 60
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
+    - type: create-der-program
+      parameters:
+        primacy: 0
     - type: set-default-der-control
       parameters:
       # The import and export values are specified as 0 in TS5573 Table 12.4.4. They have been altered for this test so
-      # that a device can follow the generation limits set in this test without being overridden. 
+      # that a device can follow the generation limits set in this test without being overridden.
         opModImpLimW: 100
         opModExpLimW: 100
         setGradW: 27

--- a/cactus_test_definitions/client/procedures/GEN-04.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-04.yaml
@@ -24,6 +24,13 @@ Preconditions:
         der_list_poll_seconds: 60
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
+    - type: set-default-der-control
+      parameters:
+      # The import and export values are specified as 0 in TS5573 Table 12.4.4. They have been altered for this test so
+      # that a device can follow the generation limits set in this test without being overridden. 
+        opModImpLimW: 100
+        opModExpLimW: 100
+        setGradW: 27
   checks:
     - type: end-device-contents
       parameters: {}
@@ -35,8 +42,6 @@ Preconditions:
         start: $(now)
         duration_seconds: 900
         opModGenLimW: $(maxExportW * 2)
-    - type: set-default-der-control
-      parameters: {}
   instructions:
     - DER shall be generating at least 50% of its active power rating.
     
@@ -75,12 +80,29 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - GET-DERC-2
+            - WAIT-RAMP-DEFAULT-DERC
       - type: remove-steps
         parameters:
           steps:
             - GET-DERC-1
 
+  WAIT-RAMP-DEFAULT-DERC:
+    instructions:
+    - DER should ramp down generation to 30% at the rate of setGradW (default 0.27%/s)
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-2
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-RAMP-DEFAULT-DERC
+  
   # (d, e) On this poll, client will discover control was cancelled and a new control will be added at 200% of setMaxW
   GET-DERC-2:
     event:
@@ -105,10 +127,29 @@ Steps:
       
   # (f, g) Waits for the new control to finish (with a bit of overtime)
   WAIT-CONTROL-END:
+    instructions:
+    - DER should discover a new control and then ramp up to unconstrained at the rate of setGradW (default 0.27%/s)
     event:
       type: wait
       parameters:
-        duration_seconds: 660
+        duration_seconds: 600
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - WAIT-RAMP-DEFAULT-DERC-2
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-END
+
+  WAIT-RAMP-DEFAULT-DERC-2:
+    instructions:
+    - DER should ramp down generation to 30% at the rate of setGradW (default 0.27%/s)
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
     actions:
       - type: enable-steps
         parameters:
@@ -117,11 +158,7 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - WAIT-CONTROL-END
-    instructions:
-    - DER should ramp down generation to 30% at the rate of setGradW (default 0.27%/s)
-    - DER should then discover a new control and then ramp up to unconstrained at the rate of setGradW (default 0.27%/s)
-    - Upon control completion, DER should then ramp down to 30% at the rate of setGradW (default 0.27%/s)
+            - WAIT-RAMP-DEFAULT-DERC-2
   
   # (h) On this poll, client will discover control the DefaultDERControl is cancelled and a new 0W control is in place
   GET-DERC-3:
@@ -147,12 +184,11 @@ Steps:
           steps:
             - GET-DERC-3
 
-
   WAIT-TEST-END:
     event:
       type: wait
       parameters:
-        duration_seconds: 120
+        duration_seconds: 120 # The device should ramp from 30% to 0 at 16%/min
     actions:
       - type: remove-steps
         parameters:

--- a/cactus_test_definitions/client/procedures/GEN-12.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-12.yaml
@@ -86,6 +86,15 @@ Preconditions:
     - type: create-der-program
       parameters:
         primacy: 0
+    - type: set-default-der-control
+      parameters:
+      # The import and export values are specified as 0 in TS5573 Table 12.4.4. They have been altered for this test so
+      # that a device can follow the generation limits set in this test without being overridden.
+      # The setGradW specified in TS5573 is 27. This has been increased for this test in order to observe DERControls
+      # during witness tests in a reasonable time frame.
+        opModImpLimW: 100
+        opModExpLimW: 100
+        setGradW: 600  # 6%/s which is about 17s for 100% to 0.
 
   checks:
     - type: end-device-contents

--- a/cactus_test_definitions/client/procedures/LOA-04.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-04.yaml
@@ -24,10 +24,13 @@ Preconditions:
         der_list_poll_seconds: 60
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
+    - type: create-der-program
+      parameters:
+        primacy: 0
     - type: set-default-der-control
       parameters:
       # The import and export values are specified as 0 in TS5573 Table 12.4.4. They have been altered for this test so
-      # that a device can follow the load limits set in this test without being overridden. 
+      # that a device can follow the load limits set in this test without being overridden.
         opModImpLimW: 100
         opModExpLimW: 100
         setGradW: 27

--- a/cactus_test_definitions/client/procedures/LOA-04.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-04.yaml
@@ -24,6 +24,13 @@ Preconditions:
         der_list_poll_seconds: 60
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
+    - type: set-default-der-control
+      parameters:
+      # The import and export values are specified as 0 in TS5573 Table 12.4.4. They have been altered for this test so
+      # that a device can follow the load limits set in this test without being overridden. 
+        opModImpLimW: 100
+        opModExpLimW: 100
+        setGradW: 27
   checks:
     - type: end-device-contents
       parameters: {}
@@ -35,8 +42,6 @@ Preconditions:
         start: $(now)
         duration_seconds: 900
         opModLoadLimW: $(maxImportW * 2)
-    - type: set-default-der-control
-      parameters: {}
   instructions:
     - DER shall be importing at least 50% of its active power rating.
     
@@ -75,11 +80,28 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - GET-DERC-2
+            - WAIT-RAMP-DEFAULT-DERC
       - type: remove-steps
         parameters:
           steps:
             - GET-DERC-1
+
+  WAIT-RAMP-DEFAULT-DERC:
+    instructions:
+    - DER should ramp down import to 30% at the rate of setGradW (default 0.27%/s)
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-2
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-RAMP-DEFAULT-DERC
 
   # (d, e) On this poll, client will discover control was cancelled and a new control will be added at 200% of setMaxW
   GET-DERC-2:
@@ -105,10 +127,29 @@ Steps:
       
   # (f, g) Waits for the new control to finish (with a bit of overtime)
   WAIT-CONTROL-END:
+    instructions:
+    - DER should discover a new control and then ramp up to unconstrained at the rate of setGradW (default 0.27%/s)
     event:
       type: wait
       parameters:
-        duration_seconds: 660
+        duration_seconds: 600
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - WAIT-RAMP-DEFAULT-DERC-2
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-END
+
+  WAIT-RAMP-DEFAULT-DERC-2:
+    instructions:
+    - DER should ramp down import to 30% at the rate of setGradW (default 0.27%/s)
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
     actions:
       - type: enable-steps
         parameters:
@@ -117,12 +158,8 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - WAIT-CONTROL-END
-    instructions:
-    - DER should ramp down import to 30% at the rate of setGradW (default 0.27%/s)
-    - DER should then discover a new control and then ramp up to unconstrained at the rate of setGradW (default 0.27%/s)
-    - Upon control completion, DER should then ramp down to 30% at the rate of setGradW (default 0.27%/s)
-  
+            - WAIT-RAMP-DEFAULT-DERC-2
+
   # (h) On this poll, client will discover control the DefaultDERControl is cancelled and a new 0W control is in place
   GET-DERC-3:
     event:
@@ -147,12 +184,11 @@ Steps:
           steps:
             - GET-DERC-3
 
-
   WAIT-TEST-END:
     event:
       type: wait
       parameters:
-        duration_seconds: 120
+        duration_seconds: 120 # The device should ramp from 30% to 0 at 16%/min
     actions:
       - type: remove-steps
         parameters:

--- a/cactus_test_definitions/client/procedures/LOA-04.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-04.yaml
@@ -33,7 +33,7 @@ Preconditions:
       # that a device can follow the load limits set in this test without being overridden.
         opModImpLimW: 100
         opModExpLimW: 100
-        setGradW: 27
+        setGradW: 167 # Increased from 27 in Table 12.4.4 to avoid two 13 minute waits without altering the test intent
   checks:
     - type: end-device-contents
       parameters: {}
@@ -91,11 +91,11 @@ Steps:
 
   WAIT-RAMP-DEFAULT-DERC:
     instructions:
-    - DER should ramp down import to 30% at the rate of setGradW (default 0.27%/s)
+    - DER should ramp down import to 30% at the rate of setGradW
     event:
       type: wait
       parameters:
-        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
+        duration_seconds: 120 # Ramp from 200 to 30% at 100%/min = 2 minutes
     actions:
       - type: enable-steps
         parameters:
@@ -131,7 +131,7 @@ Steps:
   # (f, g) Waits for the new control to finish (with a bit of overtime)
   WAIT-CONTROL-END:
     instructions:
-    - DER should discover a new control and then ramp up to unconstrained at the rate of setGradW (default 0.27%/s)
+    - DER should discover a new control and then ramp up to unconstrained at the rate of setGradW
     event:
       type: wait
       parameters:
@@ -148,11 +148,11 @@ Steps:
 
   WAIT-RAMP-DEFAULT-DERC-2:
     instructions:
-    - DER should ramp down import to 30% at the rate of setGradW (default 0.27%/s)
+    - DER should ramp down import to 30% at the rate of setGradW
     event:
       type: wait
       parameters:
-        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
+        duration_seconds: 120 # Ramp from 200 to 30% at 100%/min = 2 minutes
     actions:
       - type: enable-steps
         parameters:
@@ -191,7 +191,7 @@ Steps:
     event:
       type: wait
       parameters:
-        duration_seconds: 120 # The device should ramp from 30% to 0 at 16%/min
+        duration_seconds: 60 # The device should ramp from 30% to 0
     actions:
       - type: remove-steps
         parameters:
@@ -200,4 +200,4 @@ Steps:
       - type: finish-test
         parameters: {}
     instructions:
-    - DER shall ramp down import to 0W at the rate of setGradW (default 0.27%/s)
+    - DER shall ramp down import to 0W at the rate of setGradW

--- a/cactus_test_definitions/client/procedures/LOA-12.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-12.yaml
@@ -86,6 +86,15 @@ Preconditions:
     - type: create-der-program
       parameters:
         primacy: 0
+    - type: set-default-der-control
+      parameters:
+      # The import and export values are specified as 0 in TS5573 Table 12.4.4. They have been altered for this test so
+      # that a device can follow the load limits set in this test without being overridden.
+      # The setGradW specified in TS5573 is 27. This has been increased for this test in order to observe DERControls
+      # during witness tests in a reasonable time frame.
+        opModImpLimW: 100
+        opModExpLimW: 100
+        setGradW: 600  # 6%/s which is about 17s for 100% to 0.
 
   checks:
     - type: end-device-contents

--- a/cactus_test_definitions/client/validate.py
+++ b/cactus_test_definitions/client/validate.py
@@ -56,6 +56,38 @@ def validate_test_procedure_actions(test_procedure: TestProcedure, test_procedur
             validate_action(test_procedure, test_procedure_id, step_name, action)
 
 
+def validate_der_program_exists_before_default_control(
+    test_procedure: TestProcedure, test_procedure_id: TestProcedureId
+) -> None:
+    """set-default-der-control (without an explicit derp_id) requires a DERProgram to already exist - the runner
+    will not create one implicitly (unlike create-der-control). Ensure create-der-program/create-der-control always
+    precedes such a call, in actual execution order: init_actions, then preconditions actions, then step actions.
+
+    raises TestProcedureDefinitionError on failure
+    """
+    ordered_action_lists: list[tuple[list[Action] | None, str]] = []
+    if test_procedure.preconditions:
+        ordered_action_lists.append((test_procedure.preconditions.init_actions, "Precondition init_actions"))
+        ordered_action_lists.append((test_procedure.preconditions.actions, "Precondition actions"))
+    ordered_action_lists.extend((step.actions, step_name) for step_name, step in test_procedure.steps.items())
+
+    has_der_program = False
+    for actions, location in ordered_action_lists:
+        for action in actions or []:
+            if action.type in ("create-der-program", "create-der-control"):
+                has_der_program = True
+            elif (
+                action.type == "set-default-der-control"
+                and action.parameters.get("derp_id") is None
+                and not has_der_program
+            ):
+                raise TestProcedureDefinitionError(
+                    f"{test_procedure_id}.{location}. set-default-der-control has no derp_id and no "
+                    "create-der-program/create-der-control has executed yet - the runner has no DERProgram "
+                    "to attach the DefaultDERControl to."
+                )
+
+
 def validate_test_procedure_checks(test_procedure: TestProcedure, test_procedure_id: TestProcedureId) -> None:
     """Validate checks of a test procedure
 
@@ -96,3 +128,4 @@ def validate_test_procedure(test_procedure: TestProcedure, test_procedure_id: Te
     validate_test_procedure_actions(test_procedure, test_procedure_id)
     validate_test_procedure_checks(test_procedure, test_procedure_id)
     validate_test_procedure_events(test_procedure, test_procedure_id)
+    validate_der_program_exists_before_default_control(test_procedure, test_procedure_id)

--- a/tests/data/client/tp_invalid_default_control_before_program.yaml
+++ b/tests/data/client/tp_invalid_default_control_before_program.yaml
@@ -1,0 +1,24 @@
+
+Description: Test with set-default-der-control called before any DERProgram exists
+Category: Registration
+Classes:
+  - A
+  - DR-A
+TargetVersions:
+  - v1.2
+Preconditions:
+  init_actions:
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 100
+Steps:
+  STEP1:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /dcap
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - STEP1

--- a/tests/unit/client/test_validate.py
+++ b/tests/unit/client/test_validate.py
@@ -108,6 +108,7 @@ def collect_event_param_values(tp: TestProcedure, event_type: str, param_name: s
         Path("tests/data/client/tp_invalid_bad_param.yaml"),
         Path("tests/data/client/tp_invalid_bad_step_enable.yaml"),
         Path("tests/data/client/tp_invalid_bad_step_remove.yaml"),
+        Path("tests/data/client/tp_invalid_default_control_before_program.yaml"),
     ],
 )
 def test_TestProcedure_invalid_examples(tp_file: Path):


### PR DESCRIPTION
This PR adds default der controls to several tests. The focus of this work is on tests where strictly adhering to the default controls specified in TS5573 table 12.4.4 would interfere with the intent of the test. 

Specifically, where import and export limits interfere with gen or loa controls: e.g. setting export to 0, which prevents observation of the active generation limits. 

The CSIP-Aus Implementation Reference Group has granted permission for the test setup defaults to be altered where necessary to preserve the intent of the tests. 