### PR TITLE
Add default der controls pt3

### DIFF
--- a/cactus_test_definitions/client/procedures/GEN-03.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-03.yaml
@@ -30,7 +30,7 @@ Preconditions:
       parameters:
         opModImpLimW: 0
         opModExpLimW: 0
-        setGradW: 27
+        setGradW: 167 # Increased from 27 in Table 12.4.4 to avoid two 13 minute waits without altering the test intent
   checks:
     - type: end-device-contents
       parameters: {}
@@ -88,7 +88,7 @@ Steps:
 
   WAIT-RAMP-DEFAULT-DERC:
     instructions:
-    - DER should ramp down export to 30% at the rate of setGradW (default 0.27%/s)
+    - DER should ramp down export to 30% at the rate of setGradW
     event:
       type: wait
       parameters:
@@ -128,7 +128,7 @@ Steps:
   # (f, g) Waits for the new control to finish (with a bit of overtime)
   WAIT-CONTROL-END:
     instructions:
-    - DER should discover a new control and then ramp up to unconstrained at the rate of setGradW (default 0.27%/s)
+    - DER should discover a new control and then ramp up to unconstrained at the rate of setGradW
     event:
       type: wait
       parameters:
@@ -145,11 +145,11 @@ Steps:
 
   WAIT-RAMP-DEFAULT-DERC-2:
     instructions:
-    - DER should ramp down export to 30% at the rate of setGradW (default 0.27%/s)
+    - DER should ramp down export to 30% at the rate of setGradW
     event:
       type: wait
       parameters:
-        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
+        duration_seconds: 120 # Ramp from 200 to 30% at 100%/min = 2 minutes
     actions:
       - type: enable-steps
         parameters:
@@ -188,7 +188,7 @@ Steps:
     event:
       type: wait
       parameters:
-        duration_seconds: 120 # The device should ramp from 30% to 0 at 16%/min
+        duration_seconds: 60 # The device should ramp from 30% to 0
     actions:
       - type: remove-steps
         parameters:
@@ -197,4 +197,4 @@ Steps:
       - type: finish-test
         parameters: {}
     instructions:
-    - DER shall ramp down export to 0W at the rate of setGradW (default 0.27%/s)
+    - DER shall ramp down export to 0W at the rate of setGradW

--- a/cactus_test_definitions/client/procedures/GEN-03.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-03.yaml
@@ -23,6 +23,14 @@ Preconditions:
         der_list_poll_seconds: 60
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
+    - type: create-der-program
+      parameters:
+        primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 27
   checks:
     - type: end-device-contents
       parameters: {}
@@ -34,8 +42,6 @@ Preconditions:
         start: $(now)
         duration_seconds: 900
         opModExpLimW: $(maxExportW * 2)
-    - type: set-default-der-control
-      parameters: {}
   instructions:
     - DER shall be exporting at the connection point at least 50% of its active power rating.
     
@@ -74,11 +80,28 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - GET-DERC-2
+            - WAIT-RAMP-DEFAULT-DERC
       - type: remove-steps
         parameters:
           steps:
             - GET-DERC-1
+
+  WAIT-RAMP-DEFAULT-DERC:
+    instructions:
+    - DER should ramp down export to 30% at the rate of setGradW (default 0.27%/s)
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-2
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-RAMP-DEFAULT-DERC
 
   # (d, e) On this poll, client will discover control was cancelled and a new control will be added at 200% of setMaxW
   GET-DERC-2:
@@ -104,10 +127,29 @@ Steps:
       
   # (f, g) Waits for the new control to finish (with a bit of overtime)
   WAIT-CONTROL-END:
+    instructions:
+    - DER should discover a new control and then ramp up to unconstrained at the rate of setGradW (default 0.27%/s)
     event:
       type: wait
       parameters:
-        duration_seconds: 660
+        duration_seconds: 600
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - WAIT-RAMP-DEFAULT-DERC-2
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-END
+
+  WAIT-RAMP-DEFAULT-DERC-2:
+    instructions:
+    - DER should ramp down export to 30% at the rate of setGradW (default 0.27%/s)
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
     actions:
       - type: enable-steps
         parameters:
@@ -116,12 +158,8 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - WAIT-CONTROL-END
-    instructions:
-    - DER should ramp down export to 30% at the rate of setGradW (default 0.27%/s)
-    - DER should then discover a new control and then ramp up to unconstrained at the rate of setGradW (default 0.27%/s)
-    - Upon control completion, DER should then ramp down to 30% at the rate of setGradW (default 0.27%/s)
-  
+            - WAIT-RAMP-DEFAULT-DERC-2
+
   # (h) On this poll, client will discover control the DefaultDERControl is cancelled and a new 0W control is in place
   GET-DERC-3:
     event:
@@ -146,12 +184,11 @@ Steps:
           steps:
             - GET-DERC-3
 
-
   WAIT-TEST-END:
     event:
       type: wait
       parameters:
-        duration_seconds: 120
+        duration_seconds: 120 # The device should ramp from 30% to 0 at 16%/min
     actions:
       - type: remove-steps
         parameters:

--- a/cactus_test_definitions/client/procedures/GEN-07.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-07.yaml
@@ -53,7 +53,7 @@ Preconditions:
       parameters:
         opModImpLimW: 0
         opModExpLimW: $(maxExportW * 0.3)
-        setGradW: 27
+        setGradW: 167 # Increased from 27 in Table 12.4.4 to avoid two 13 minute waits without altering the test intent
   instructions:
     - EndDevice should be registered with active subscriptions before starting.
     - DER shall be exporting at the connection point with at least 50% of its active power rating.
@@ -85,7 +85,7 @@ Steps:
     event:
       type: wait
       parameters:
-        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
+        duration_seconds: 120 # Ramp from 200 to 30% at 100%/min = 2 minutes
     actions:
       - type: create-der-control
         parameters:
@@ -101,7 +101,7 @@ Steps:
           steps:
             - WAIT-DEVICE-RAMP
     instructions:
-      - DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW (default 0.27%/s).
+      - DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW
 
   # (f, g, h)
   WAIT-CONTROL-FINISH:
@@ -119,13 +119,13 @@ Steps:
           steps:
             - WAIT-CONTROL-FINISH
     instructions:
-      - DER should ramp up to the active DERControl unconstrained value at rate setGradW (default 0.27%/s).
+      - DER should ramp up to the active DERControl unconstrained value at rate setGradW
 
   WAIT-RAMP-DEFAULT-DERC:
     event:
       type: wait
       parameters:
-        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
+        duration_seconds: 120 # Ramp from 200 to 30% at 100%/min = 2 minutes
     actions:
       - type: create-der-control
         parameters:
@@ -144,14 +144,14 @@ Steps:
           steps:
             - WAIT-RAMP-DEFAULT-DERC
     instructions:
-      - Upon completion of the active DERControl (10 minutes) the DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW (default 0.27%/s).
+      - Upon completion of the active DERControl (10 minutes) the DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW
 
   # (i)
   WAIT-TEST-FINISH:
     event:
       type: wait
       parameters:
-        duration_seconds: 120 # The device should ramp from 30% to 0 at 16%/min
+        duration_seconds: 60 # The device should ramp from 30% to 0
     actions:
       - type: remove-steps
         parameters:
@@ -160,4 +160,4 @@ Steps:
       - type: finish-test
         parameters: {}
     instructions:
-      - DER should ramp down to the active DERControl 0W value at rate setGradW (default 0.27%/s).
+      - DER should ramp down to the active DERControl 0W value at rate setGradW

--- a/cactus_test_definitions/client/procedures/GEN-07.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-07.yaml
@@ -51,7 +51,9 @@ Preconditions:
     # (a, b)
     - type: set-default-der-control
       parameters:
+        opModImpLimW: 0
         opModExpLimW: $(maxExportW * 0.3)
+        setGradW: 27
   instructions:
     - EndDevice should be registered with active subscriptions before starting.
     - DER shall be exporting at the connection point with at least 50% of its active power rating.
@@ -83,7 +85,7 @@ Steps:
     event:
       type: wait
       parameters:
-        duration_seconds: 120
+        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
     actions:
       - type: create-der-control
         parameters:
@@ -99,14 +101,31 @@ Steps:
           steps:
             - WAIT-DEVICE-RAMP
     instructions:
-      - DER should be ramping to the DefaultDERControl value of 30% max power at rate setGradW (default 0.27%/s).
+      - DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW (default 0.27%/s).
 
   # (f, g, h)
   WAIT-CONTROL-FINISH:
     event:
       type: wait
       parameters:
-        duration_seconds: 720
+        duration_seconds: 600
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - WAIT-RAMP-DEFAULT-DERC
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-FINISH
+    instructions:
+      - DER should ramp up to the active DERControl unconstrained value at rate setGradW (default 0.27%/s).
+
+  WAIT-RAMP-DEFAULT-DERC:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
     actions:
       - type: create-der-control
         parameters:
@@ -116,7 +135,6 @@ Steps:
       - type: set-default-der-control
         parameters:
           cancelled: true
-
       - type: enable-steps
         parameters:
           steps:
@@ -124,17 +142,16 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - WAIT-CONTROL-FINISH
+            - WAIT-RAMP-DEFAULT-DERC
     instructions:
-      - DER should be ramping to the active DERControl unconstrained value at rate setGradW (default 0.27%/s).
-      - Upon completion of the active DERControl (10 minutes) the DER should ramp to the DefaultDERControl value of 30% max power.
+      - Upon completion of the active DERControl (10 minutes) the DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW (default 0.27%/s).
 
   # (i)
   WAIT-TEST-FINISH:
     event:
       type: wait
       parameters:
-        duration_seconds: 720
+        duration_seconds: 120 # The device should ramp from 30% to 0 at 16%/min
     actions:
       - type: remove-steps
         parameters:
@@ -143,4 +160,4 @@ Steps:
       - type: finish-test
         parameters: {}
     instructions:
-      - DER should be ramping to the active DERControl 0W value at rate setGradW (default 0.27%/s).
+      - DER should ramp down to the active DERControl 0W value at rate setGradW (default 0.27%/s).

--- a/cactus_test_definitions/client/procedures/GEN-08.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-08.yaml
@@ -55,7 +55,7 @@ Preconditions:
         opModExpLimW: $(maxExportW) # TS5573 sets this to 0, however we must set it to 100%
         # To avoid curtailing generation which is the purpose of this test
         opModGenLimW: $(maxExportW * 0.3)
-        setGradW: 27
+        setGradW:  167 # Increased from 27 in Table 12.4.4 to avoid two 13 minute waits without altering the test intent
   instructions:
     - EndDevice should be registered with active subscriptions before starting.
     - DER shall be generating at least 50% of its active power rating.
@@ -87,7 +87,7 @@ Steps:
     event:
       type: wait
       parameters:
-        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
+        duration_seconds: 120 # Ramp from 200 to 30% at 100%/min = 2 minutes
     actions:
       - type: create-der-control
         parameters:
@@ -103,7 +103,7 @@ Steps:
           steps:
             - WAIT-DEVICE-RAMP
     instructions:
-      - DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW (default 0.27%/s).
+      - DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW
 
   # (f, g, h)
   WAIT-CONTROL-FINISH:
@@ -121,13 +121,13 @@ Steps:
           steps:
             - WAIT-CONTROL-FINISH
     instructions:
-      - DER should ramp up to the active DERControl unconstrained value at rate setGradW (default 0.27%/s).
+      - DER should ramp up to the active DERControl unconstrained value at rate setGradW
 
   WAIT-RAMP-DEFAULT-DERC:
     event:
       type: wait
       parameters:
-        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
+        duration_seconds: 120 # Ramp from 200 to 30% at 100%/min = 2 minutes
     actions:
       - type: create-der-control
         parameters:
@@ -146,14 +146,14 @@ Steps:
           steps:
             - WAIT-RAMP-DEFAULT-DERC
     instructions:
-      - Upon completion of the active DERControl (10 minutes) the DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW (default 0.27%/s).
+      - Upon completion of the active DERControl (10 minutes) the DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW
 
   # (i)
   WAIT-TEST-FINISH:
     event:
       type: wait
       parameters:
-        duration_seconds: 120 # The device should ramp from 30% to 0 at 16%/min
+        duration_seconds: 60 # The device should ramp from 30% to 0
     actions:
       - type: remove-steps
         parameters:
@@ -162,4 +162,4 @@ Steps:
       - type: finish-test
         parameters: {}
     instructions:
-      - DER should ramp down to the active DERControl 0W value at rate setGradW (default 0.27%/s).
+      - DER should ramp down to the active DERControl 0W value at rate setGradW

--- a/cactus_test_definitions/client/procedures/GEN-08.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-08.yaml
@@ -51,7 +51,11 @@ Preconditions:
     # (a, b)
     - type: set-default-der-control
       parameters:
+        opModImpLimW: 0
+        opModExpLimW: $(maxExportW) # TS5573 sets this to 0, however we must set it to 100%
+        # To avoid curtailing generation which is the purpose of this test
         opModGenLimW: $(maxExportW * 0.3)
+        setGradW: 27
   instructions:
     - EndDevice should be registered with active subscriptions before starting.
     - DER shall be generating at least 50% of its active power rating.
@@ -83,7 +87,7 @@ Steps:
     event:
       type: wait
       parameters:
-        duration_seconds: 120
+        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
     actions:
       - type: create-der-control
         parameters:
@@ -99,14 +103,31 @@ Steps:
           steps:
             - WAIT-DEVICE-RAMP
     instructions:
-      - DER should be ramping to the DefaultDERControl value of 30% max power at rate setGradW (default 0.27%/s).
+      - DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW (default 0.27%/s).
 
   # (f, g, h)
   WAIT-CONTROL-FINISH:
     event:
       type: wait
       parameters:
-        duration_seconds: 720
+        duration_seconds: 600
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - WAIT-RAMP-DEFAULT-DERC
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-FINISH
+    instructions:
+      - DER should ramp up to the active DERControl unconstrained value at rate setGradW (default 0.27%/s).
+
+  WAIT-RAMP-DEFAULT-DERC:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
     actions:
       - type: create-der-control
         parameters:
@@ -116,7 +137,6 @@ Steps:
       - type: set-default-der-control
         parameters:
           cancelled: true
-
       - type: enable-steps
         parameters:
           steps:
@@ -124,17 +144,16 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - WAIT-CONTROL-FINISH
+            - WAIT-RAMP-DEFAULT-DERC
     instructions:
-      - DER should be ramping to the active DERControl unconstrained value at rate setGradW (default 0.27%/s).
-      - Upon completion of the active DERControl (10 minutes) the DER should ramp to the DefaultDERControl value of 30% max power.
+      - Upon completion of the active DERControl (10 minutes) the DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW (default 0.27%/s).
 
   # (i)
   WAIT-TEST-FINISH:
     event:
       type: wait
       parameters:
-        duration_seconds: 720
+        duration_seconds: 120 # The device should ramp from 30% to 0 at 16%/min
     actions:
       - type: remove-steps
         parameters:
@@ -143,4 +162,4 @@ Steps:
       - type: finish-test
         parameters: {}
     instructions:
-      - DER should be ramping to the active DERControl 0W value at rate setGradW (default 0.27%/s).
+      - DER should ramp down to the active DERControl 0W value at rate setGradW (default 0.27%/s).

--- a/cactus_test_definitions/client/procedures/GEN-09.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-09.yaml
@@ -34,7 +34,10 @@ Preconditions:
         primacy: 0
     - type: set-default-der-control
       parameters:
+        opModImpLimW: 0
         opModExpLimW: $(maxExportW * 0.3)
+        setGradW: 600 # This is increased from the 27 specified in TS5573 Table 12.4.4 in order for the ramp 
+        # Behaviour to be observed in a reasonable time frame
   instructions: 
     - DER should be exporting at least 50% of its rated power.
     
@@ -105,7 +108,7 @@ Steps:
     event:
       type: wait
       parameters:
-        duration_seconds: 180
+        duration_seconds: 60
     actions:
       - type: remove-steps
         parameters:

--- a/cactus_test_definitions/client/procedures/LOA-03.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-03.yaml
@@ -23,6 +23,14 @@ Preconditions:
         der_list_poll_seconds: 60
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
+    - type: create-der-program
+      parameters:
+        primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 27
   checks:
     - type: end-device-contents
       parameters: {}
@@ -34,8 +42,6 @@ Preconditions:
         start: $(now)
         duration_seconds: 900
         opModImpLimW: $(maxImportW * 2)
-    - type: set-default-der-control
-      parameters: {}
   instructions:
     - DER shall be importing at the connection point at least 50% of its active power rating.
     
@@ -74,11 +80,28 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - GET-DERC-2
+            - WAIT-RAMP-DEFAULT-DERC
       - type: remove-steps
         parameters:
           steps:
             - GET-DERC-1
+
+  WAIT-RAMP-DEFAULT-DERC:
+    instructions:
+    - DER should ramp down import to 30% at the rate of setGradW (default 0.27%/s)
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-2
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-RAMP-DEFAULT-DERC
 
   # (d, e) On this poll, client will discover control was cancelled and a new control will be added at 200% of setMaxW
   GET-DERC-2:
@@ -104,10 +127,29 @@ Steps:
       
   # (f, g) Waits for the new control to finish (with a bit of overtime)
   WAIT-CONTROL-END:
+    instructions:
+    - DER should discover a new control and then ramp up to unconstrained at the rate of setGradW (default 0.27%/s)
     event:
       type: wait
       parameters:
-        duration_seconds: 660
+        duration_seconds: 600
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - WAIT-RAMP-DEFAULT-DERC-2
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-END
+
+  WAIT-RAMP-DEFAULT-DERC-2:
+    instructions:
+    - DER should ramp down import to 30% at the rate of setGradW (default 0.27%/s)
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
     actions:
       - type: enable-steps
         parameters:
@@ -116,12 +158,8 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - WAIT-CONTROL-END
-    instructions:
-    - DER should ramp down import to 30% at the rate of setGradW (default 0.27%/s)
-    - DER should then discover a new control and then ramp up to unconstrained at the rate of setGradW (default 0.27%/s)
-    - Upon control completion, DER should then ramp down to 30% at the rate of setGradW (default 0.27%/s)
-  
+            - WAIT-RAMP-DEFAULT-DERC-2
+
   # (h) On this poll, client will discover control the DefaultDERControl is cancelled and a new 0W control is in place
   GET-DERC-3:
     event:
@@ -146,12 +184,11 @@ Steps:
           steps:
             - GET-DERC-3
 
-
   WAIT-TEST-END:
     event:
       type: wait
       parameters:
-        duration_seconds: 120
+        duration_seconds: 120 # The device should ramp from 30% to 0 at 16%/min
     actions:
       - type: remove-steps
         parameters:

--- a/cactus_test_definitions/client/procedures/LOA-03.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-03.yaml
@@ -30,7 +30,7 @@ Preconditions:
       parameters:
         opModImpLimW: 0
         opModExpLimW: 0
-        setGradW: 27
+        setGradW: 167 # Increased from 27 in Table 12.4.4 to avoid two 13 minute waits without altering the test intent
   checks:
     - type: end-device-contents
       parameters: {}
@@ -88,11 +88,11 @@ Steps:
 
   WAIT-RAMP-DEFAULT-DERC:
     instructions:
-    - DER should ramp down import to 30% at the rate of setGradW (default 0.27%/s)
+    - DER should ramp down import to 30% at the rate of setGradW
     event:
       type: wait
       parameters:
-        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
+        duration_seconds: 120 # Ramp from 200 to 30% at 100%/min = 2 minutes
     actions:
       - type: enable-steps
         parameters:
@@ -128,7 +128,7 @@ Steps:
   # (f, g) Waits for the new control to finish (with a bit of overtime)
   WAIT-CONTROL-END:
     instructions:
-    - DER should discover a new control and then ramp up to unconstrained at the rate of setGradW (default 0.27%/s)
+    - DER should discover a new control and then ramp up to unconstrained at the rate of setGradW
     event:
       type: wait
       parameters:
@@ -145,11 +145,11 @@ Steps:
 
   WAIT-RAMP-DEFAULT-DERC-2:
     instructions:
-    - DER should ramp down import to 30% at the rate of setGradW (default 0.27%/s)
+    - DER should ramp down import to 30% at the rate of setGradW
     event:
       type: wait
       parameters:
-        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
+        duration_seconds: 120 # Ramp from 200 to 30% at 100%/min = 2 minutes
     actions:
       - type: enable-steps
         parameters:
@@ -188,7 +188,7 @@ Steps:
     event:
       type: wait
       parameters:
-        duration_seconds: 120 # The device should ramp from 30% to 0 at 16%/min
+        duration_seconds: 60 # The device should ramp from 30% to 0
     actions:
       - type: remove-steps
         parameters:
@@ -197,4 +197,4 @@ Steps:
       - type: finish-test
         parameters: {}
     instructions:
-    - DER shall ramp down import to 0W at the rate of setGradW (default 0.27%/s)
+    - DER shall ramp down import to 0W at the rate of setGradW

--- a/cactus_test_definitions/client/procedures/LOA-07.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-07.yaml
@@ -53,7 +53,7 @@ Preconditions:
       parameters:
         opModImpLimW: $(maxImportW * 0.3)
         opModExpLimW: 0
-        setGradW: 27
+        setGradW: 167 # Increased from 27 in Table 12.4.4 to avoid two 13 minute waits without altering the test intent
   instructions:
     - EndDevice should be registered with active subscriptions before starting.
     - DER shall be importing from the connection point with at least 50% of its active power rating.
@@ -85,7 +85,7 @@ Steps:
     event:
       type: wait
       parameters:
-        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
+        duration_seconds: 120 # Ramp from 200 to 30% at 100%/min = 2 minutes
     actions:
       - type: create-der-control
         parameters:
@@ -101,7 +101,7 @@ Steps:
           steps:
             - WAIT-DEVICE-RAMP
     instructions:
-      - DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW (default 0.27%/s).
+      - DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW
 
   # (f, g, h)
   WAIT-CONTROL-FINISH:
@@ -119,13 +119,13 @@ Steps:
           steps:
             - WAIT-CONTROL-FINISH
     instructions:
-      - DER should ramp up to the active DERControl unconstrained value at rate setGradW (default 0.27%/s).
+      - DER should ramp up to the active DERControl unconstrained value at rate setGradW
 
   WAIT-RAMP-DEFAULT-DERC:
     event:
       type: wait
       parameters:
-        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
+        duration_seconds: 120 # Ramp from 200 to 30% at 100%/min = 2 minutes
     actions:
       - type: create-der-control
         parameters:
@@ -144,14 +144,14 @@ Steps:
           steps:
             - WAIT-RAMP-DEFAULT-DERC
     instructions:
-      - Upon completion of the active DERControl (10 minutes) the DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW (default 0.27%/s).
+      - Upon completion of the active DERControl (10 minutes) the DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW
 
   # (i)
   WAIT-TEST-FINISH:
     event:
       type: wait
       parameters:
-        duration_seconds: 120 # The device should ramp from 30% to 0 at 16%/min
+        duration_seconds: 60 # The device should ramp from 30% to 0
     actions:
       - type: remove-steps
         parameters:
@@ -160,4 +160,4 @@ Steps:
       - type: finish-test
         parameters: {}
     instructions:
-      - DER should ramp down to the active DERControl 0W value at rate setGradW (default 0.27%/s).
+      - DER should ramp down to the active DERControl 0W value at rate setGradW

--- a/cactus_test_definitions/client/procedures/LOA-07.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-07.yaml
@@ -52,6 +52,8 @@ Preconditions:
     - type: set-default-der-control
       parameters:
         opModImpLimW: $(maxImportW * 0.3)
+        opModExpLimW: 0
+        setGradW: 27
   instructions:
     - EndDevice should be registered with active subscriptions before starting.
     - DER shall be importing from the connection point with at least 50% of its active power rating.
@@ -83,7 +85,7 @@ Steps:
     event:
       type: wait
       parameters:
-        duration_seconds: 120
+        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
     actions:
       - type: create-der-control
         parameters:
@@ -99,14 +101,31 @@ Steps:
           steps:
             - WAIT-DEVICE-RAMP
     instructions:
-      - DER should be ramping to the DefaultDERControl value of 30% max power at rate setGradW (default 0.27%/s).
+      - DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW (default 0.27%/s).
 
   # (f, g, h)
   WAIT-CONTROL-FINISH:
     event:
       type: wait
       parameters:
-        duration_seconds: 720
+        duration_seconds: 600
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - WAIT-RAMP-DEFAULT-DERC
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-FINISH
+    instructions:
+      - DER should ramp up to the active DERControl unconstrained value at rate setGradW (default 0.27%/s).
+
+  WAIT-RAMP-DEFAULT-DERC:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
     actions:
       - type: create-der-control
         parameters:
@@ -116,7 +135,6 @@ Steps:
       - type: set-default-der-control
         parameters:
           cancelled: true
-
       - type: enable-steps
         parameters:
           steps:
@@ -124,17 +142,16 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - WAIT-CONTROL-FINISH
+            - WAIT-RAMP-DEFAULT-DERC
     instructions:
-      - DER should be ramping to the active DERControl unconstrained value at rate setGradW (default 0.27%/s).
-      - Upon completion of the active DERControl (10 minutes) the DER should ramp to the DefaultDERControl value of 30% max power.
+      - Upon completion of the active DERControl (10 minutes) the DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW (default 0.27%/s).
 
   # (i)
   WAIT-TEST-FINISH:
     event:
       type: wait
       parameters:
-        duration_seconds: 720
+        duration_seconds: 120 # The device should ramp from 30% to 0 at 16%/min
     actions:
       - type: remove-steps
         parameters:
@@ -143,4 +160,4 @@ Steps:
       - type: finish-test
         parameters: {}
     instructions:
-      - DER should be ramping to the active DERControl 0W value at rate setGradW (default 0.27%/s).
+      - DER should ramp down to the active DERControl 0W value at rate setGradW (default 0.27%/s).

--- a/cactus_test_definitions/client/procedures/LOA-08.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-08.yaml
@@ -51,7 +51,11 @@ Preconditions:
     # (a, b)
     - type: set-default-der-control
       parameters:
+        opModExpLimW: 0
+        opModImpLimW: $(maxExportW) # TS5573 sets this to 0, however we must set it to 100%
+        # To avoid curtailing load which is the purpose of this test
         opModLoadLimW: $(maxImportW * 0.3)
+        setGradW: 27
   instructions:
     - EndDevice should be registered with active subscriptions before starting.
     - DER shall be consuming at least 50% of its active power rating.
@@ -83,7 +87,7 @@ Steps:
     event:
       type: wait
       parameters:
-        duration_seconds: 120
+        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
     actions:
       - type: create-der-control
         parameters:
@@ -99,14 +103,31 @@ Steps:
           steps:
             - WAIT-DEVICE-RAMP
     instructions:
-      - DER should be ramping to the DefaultDERControl value of 30% max power at rate setGradW (default 0.27%/s).
+      - DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW (default 0.27%/s).
 
   # (f, g, h)
   WAIT-CONTROL-FINISH:
     event:
       type: wait
       parameters:
-        duration_seconds: 720
+        duration_seconds: 600
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - WAIT-RAMP-DEFAULT-DERC
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL-FINISH
+    instructions:
+      - DER should ramp up to the active DERControl unconstrained value at rate setGradW (default 0.27%/s).
+
+  WAIT-RAMP-DEFAULT-DERC:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
     actions:
       - type: create-der-control
         parameters:
@@ -116,7 +137,6 @@ Steps:
       - type: set-default-der-control
         parameters:
           cancelled: true
-
       - type: enable-steps
         parameters:
           steps:
@@ -124,17 +144,16 @@ Steps:
       - type: remove-steps
         parameters:
           steps:
-            - WAIT-CONTROL-FINISH
+            - WAIT-RAMP-DEFAULT-DERC
     instructions:
-      - DER should be ramping to the active DERControl unconstrained value at rate setGradW (default 0.27%/s).
-      - Upon completion of the active DERControl (10 minutes) the DER should ramp to the DefaultDERControl value of 30% max power.
+      - Upon completion of the active DERControl (10 minutes) the DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW (default 0.27%/s).
 
   # (i)
   WAIT-TEST-FINISH:
     event:
       type: wait
       parameters:
-        duration_seconds: 720
+        duration_seconds: 120 # The device should ramp from 30% to 0 at 16%/min
     actions:
       - type: remove-steps
         parameters:
@@ -143,4 +162,4 @@ Steps:
       - type: finish-test
         parameters: {}
     instructions:
-      - DER should be ramping to the active DERControl 0W value at rate setGradW (default 0.27%/s).
+      - DER should ramp down to the active DERControl 0W value at rate setGradW (default 0.27%/s).

--- a/cactus_test_definitions/client/procedures/LOA-08.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-08.yaml
@@ -55,7 +55,7 @@ Preconditions:
         opModImpLimW: $(maxExportW) # TS5573 sets this to 0, however we must set it to 100%
         # To avoid curtailing load which is the purpose of this test
         opModLoadLimW: $(maxImportW * 0.3)
-        setGradW: 27
+        setGradW: 167 # Increased from 27 in Table 12.4.4 to avoid two 13 minute waits without altering the test intent
   instructions:
     - EndDevice should be registered with active subscriptions before starting.
     - DER shall be consuming at least 50% of its active power rating.
@@ -87,7 +87,7 @@ Steps:
     event:
       type: wait
       parameters:
-        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
+        duration_seconds: 120 # Ramp from 200 to 30% at 100%/min = 2 minutes
     actions:
       - type: create-der-control
         parameters:
@@ -103,7 +103,7 @@ Steps:
           steps:
             - WAIT-DEVICE-RAMP
     instructions:
-      - DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW (default 0.27%/s).
+      - DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW
 
   # (f, g, h)
   WAIT-CONTROL-FINISH:
@@ -121,13 +121,13 @@ Steps:
           steps:
             - WAIT-CONTROL-FINISH
     instructions:
-      - DER should ramp up to the active DERControl unconstrained value at rate setGradW (default 0.27%/s).
+      - DER should ramp up to the active DERControl unconstrained value at rate setGradW
 
   WAIT-RAMP-DEFAULT-DERC:
     event:
       type: wait
       parameters:
-        duration_seconds: 780 # Ramp from 200 to 30% at 0.27%/s = 13 minutes
+        duration_seconds: 120 # Ramp from 200 to 30% at 100%/min = 2 minutes
     actions:
       - type: create-der-control
         parameters:
@@ -146,14 +146,14 @@ Steps:
           steps:
             - WAIT-RAMP-DEFAULT-DERC
     instructions:
-      - Upon completion of the active DERControl (10 minutes) the DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW (default 0.27%/s).
+      - Upon completion of the active DERControl (10 minutes) the DER should ramp down to the DefaultDERControl value of 30% max power at rate setGradW
 
   # (i)
   WAIT-TEST-FINISH:
     event:
       type: wait
       parameters:
-        duration_seconds: 120 # The device should ramp from 30% to 0 at 16%/min
+        duration_seconds: 60 # The device should ramp from 30% to 0
     actions:
       - type: remove-steps
         parameters:
@@ -162,4 +162,4 @@ Steps:
       - type: finish-test
         parameters: {}
     instructions:
-      - DER should ramp down to the active DERControl 0W value at rate setGradW (default 0.27%/s).
+      - DER should ramp down to the active DERControl 0W value at rate setGradW

--- a/cactus_test_definitions/client/procedures/LOA-09.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-09.yaml
@@ -34,7 +34,10 @@ Preconditions:
         primacy: 0
     - type: set-default-der-control
       parameters:
+        opModExpLimW: 0
         opModImpLimW: $(maxImportW * 0.3)
+        setGradW: 600 # This is increased from the 27 specified in TS5573 Table 12.4.4 in order for the ramp 
+        # Behaviour to be observed in a reasonable time frame
   instructions: 
     - DER should be importing at least 50% of its rated power.
     
@@ -105,7 +108,7 @@ Steps:
     event:
       type: wait
       parameters:
-        duration_seconds: 120
+        duration_seconds: 60
     actions:
       - type: remove-steps
         parameters:

--- a/cactus_test_definitions/client/procedures/MUL-01.yaml
+++ b/cactus_test_definitions/client/procedures/MUL-01.yaml
@@ -24,6 +24,14 @@ Preconditions:
         der_list_poll_seconds: 60 
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
+    - type: create-der-program
+      parameters:         
+        primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 27
   checks:
     - type: end-device-contents
       parameters: {}

--- a/cactus_test_definitions/client/procedures/MUL-02.yaml
+++ b/cactus_test_definitions/client/procedures/MUL-02.yaml
@@ -35,7 +35,14 @@ Preconditions:
         der_list_poll_seconds: 60 
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
-
+    - type: create-der-program
+      parameters:         
+        primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 600 # This is increased from the 27 specified in TS5573 table 12.4.4 in order to ramp controls within a reasonable time frame
   checks:
     - type: end-device-contents
       parameters: {}

--- a/cactus_test_definitions/client/procedures/MUL-03.yaml
+++ b/cactus_test_definitions/client/procedures/MUL-03.yaml
@@ -33,6 +33,11 @@ Preconditions:
     - type: create-der-program
       parameters:
         primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 27
 
 Steps:
   


### PR DESCRIPTION
This PR adds default der controls to several tests. The focus of this work is on tests where minimal or no changes are made to the default controls specified in TS5573 table 12.4.4.

The CSIP-Aus Implementation Reference Group has granted permission for the test setup defaults to be altered where necessary to preserve the intent of the tests.