### PR TITLE
Add default der controls pt4

### DIFF
--- a/cactus_test_definitions/client/procedures/ALL-29.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-29.yaml
@@ -29,6 +29,14 @@ Preconditions:
         der_list_poll_seconds: 60
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
+    - type: create-der-program
+      parameters:
+        primacy: 0  
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 600 # Altered from 27 defined in TS5573 table 12.4.4 so that control observation is not limited by slow ramping
   checks:
     - type: end-device-contents
       parameters: {}

--- a/cactus_test_definitions/client/procedures/ALL-30.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-30.yaml
@@ -36,7 +36,7 @@ Preconditions:
       parameters:
         opModExpLimW: $(maxExportW * 0.3)
         opModImpLimW: $(maxImportW * 0.3)
-        
+        setGradW: 600 # Altered from 27 defined in TS5573 table 12.4.4 so that control observation is not limited by slow ramping
   instructions:
     - DER is operating at least 50% if its rated power.
 

--- a/cactus_test_definitions/client/procedures/GEN-01.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-01.yaml
@@ -23,6 +23,14 @@ Preconditions:
         der_list_poll_seconds: 60
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
+    - type: create-der-program
+      parameters:         
+        primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 600 # This is increased from the 27 defined in TS5573 Table 12.4.4 in order to comply with the <30s ramp specified in step c
   checks:
     - type: end-device-contents
       parameters: {}
@@ -48,11 +56,26 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - GET-DERC-ZERO
+            - WAIT-CONTROL
       - type: remove-steps
         parameters:
           steps:
             - GET-DERC-INITIAL
+
+  WAIT-CONTROL:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 60 # Wait for the control to reach at least 50%
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-ZERO
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL
 
   # (a, b, c)
   GET-DERC-ZERO:
@@ -66,9 +89,24 @@ Steps:
           start: $(now)
           duration_seconds: 300
           opModExpLimW: 0
+      - type: enable-steps
+        parameters:
+          steps:
+            - WAIT-REACH-ZERO
       - type: remove-steps
         parameters:
           steps:
             - GET-DERC-ZERO
-          
-  
+
+  WAIT-REACH-ZERO:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120 # Wait for the control to be polled, then to reach 0
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-REACH-ZERO
+      - type: finish-test
+        parameters: {}

--- a/cactus_test_definitions/client/procedures/GEN-02.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-02.yaml
@@ -24,6 +24,14 @@ Preconditions:
         der_list_poll_seconds: 60
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
+    - type: create-der-program
+      parameters:
+        primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 100 # Increased from the 0 efined in TS5573 Table 12.4.4 in order to observe the GEN limit changes without overriding them
+        setGradW: 600 # This is increased from the 27 defined in TS5573 Table 12.4.4 in order to comply with the <30s ramp specified in step c
   checks:
     - type: end-device-contents
       parameters: {}
@@ -49,11 +57,26 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - GET-DERC-ZERO
+            - WAIT-CONTROL
       - type: remove-steps
         parameters:
           steps:
             - GET-DERC-INITIAL
+
+  WAIT-CONTROL:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 60 # Wait for the control to reach at least 50%
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-ZERO
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL
 
   # (a, b, c)
   GET-DERC-ZERO:
@@ -67,7 +90,24 @@ Steps:
           start: $(now)
           duration_seconds: 300
           opModGenLimW: 0
+      - type: enable-steps
+        parameters:
+          steps:
+            - WAIT-REACH-ZERO
       - type: remove-steps
         parameters:
           steps:
             - GET-DERC-ZERO
+
+  WAIT-REACH-ZERO:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120 # Wait for the control to be polled, then to reach 0
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-REACH-ZERO
+      - type: finish-test
+        parameters: {}

--- a/cactus_test_definitions/client/procedures/GEN-05.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-05.yaml
@@ -29,6 +29,11 @@ Preconditions:
     - type: create-der-program
       parameters:
         primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 600 # This is increased from the 27 defined in TS5573 Table 12.4.4 in order to comply ramps specified
 
   checks:
     - type: end-device-contents
@@ -54,12 +59,12 @@ Steps:
   # NOTE - The majority of this test's validation is watching 
 
   # (a, b, c)
-  # After a short delay (to allow precondition actions to propagate subscriptions)
+  # After a short delay (to allow precondition actions to propagate subscriptions) and for device to ramp to full power
   WAIT-CREATE-DERC:
     event:
       type: wait
       parameters:
-        duration_seconds: 60
+        duration_seconds: 90
     actions:
       - type: create-der-control
         parameters:
@@ -80,11 +85,11 @@ Steps:
     event:
       type: wait
       parameters:
-        duration_seconds: 480 # enough time for the control to start, run and then finish
+        duration_seconds: 60 # enough time for the control to be received and ramp down
     actions:
       - type: remove-steps
         parameters:
           steps:
             - WAIT-TEST-FINISH
     instructions:
-      - DER should be observed ramping to and then from 0W control.
+      - DER should be observed ramping to the 0W control.

--- a/cactus_test_definitions/client/procedures/GEN-06.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-06.yaml
@@ -29,7 +29,12 @@ Preconditions:
     - type: create-der-program
       parameters:
         primacy: 0
-        
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 100 # Increased from the 0 defined in TS5573 Table 12.4.4 in order to observe the GEN limit changes without overriding them
+        setGradW: 600 # This is increased from the 27 defined in TS5573 Table 12.4.4 in order to comply with the ramps specified
+
   checks:
     - type: end-device-contents
       parameters: {}
@@ -55,12 +60,12 @@ Steps:
   # NOTE - The majority of this test's validation is watching 
 
   # (a, b, c)
-  # After a short delay (to allow precondition actions to propagate subscriptions)
+  # After a short delay (to allow precondition actions to propagate subscriptions) and for device to ramp to full power
   WAIT-CREATE-DERC:
     event:
       type: wait
       parameters:
-        duration_seconds: 60
+        duration_seconds: 90
     actions:
       - type: create-der-control
         parameters:
@@ -81,11 +86,11 @@ Steps:
     event:
       type: wait
       parameters:
-        duration_seconds: 480 # enough time for the control to start, run and then finish
+        duration_seconds: 60 # enough time for the control to be received and ramp down
     actions:
       - type: remove-steps
         parameters:
           steps:
             - WAIT-TEST-FINISH
     instructions:
-      - DER should be observed ramping to and then from 0W control.
+      - DER should be observed ramping to the 0W control.

--- a/cactus_test_definitions/client/procedures/GEN-10.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-10.yaml
@@ -98,18 +98,18 @@ Preconditions:
       parameters:
         derp_id: 1
         opModImpLimW: 0
-        setGradW: 167 # hundredths of a percent - this is 1.67% / second
-    # These default controls are not explicitly in the standards (SA TS5573), but we are adding here to let the 
-    # client know to keep polling at, e.g., /edev/1/derp/6/dderc, which allows step-bb-ii to work without using notifications.
-    # Previously, polling at /edev/1/derp/6/dderc was expected without any defaults being set.
+        opModExpLimW: 0
+        setGradW: 167 # Altered from 27 defined in TS5573 table 12.4.4 so that control observation is not limited by slow ramping
+        # A slow ramp would interfere with many explicitly defined control times in the test
     - type: set-default-der-control
       parameters:
         derp_id: 6
-        opModImpLimW: 0 # Set to import to not interefere with export observations in witness test
-        setGradW: 167 # hundredths of a percent - this is 1.67% / second
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 167 # Altered from 27 defined in TS5573 table 12.4.4 so that control observation is not limited by slow ramping
+        # A slow ramp would interfere with many explicitly defined control times in the test
 
 Steps:
-
   # (a, b) - Create a Default DERControl at DERP 1 - set to 30% of max
   GET-DEFAULT-DERC:
     event:

--- a/cactus_test_definitions/client/procedures/GEN-11.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-11.yaml
@@ -85,7 +85,12 @@ Preconditions:
         mup_post_seconds: 60
     - type: create-der-program
       parameters:
-        primacy: 0
+        primacy: 0  
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 600 # Altered from 27 defined in TS5573 table 12.4.4 so that control observation is not limited by slow ramping
 
   checks:
     - type: end-device-contents

--- a/cactus_test_definitions/client/procedures/GEN-13.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-13.yaml
@@ -23,6 +23,14 @@ Preconditions:
         der_list_poll_seconds: 60 
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
+    - type: create-der-program
+      parameters:
+        primacy: 0  
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 600 # Altered from 27 defined in TS5573 table 12.4.4 so that control observation is not limited by slow ramping
   checks:
     - type: end-device-contents
       parameters: {}

--- a/cactus_test_definitions/client/procedures/LOA-01.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-01.yaml
@@ -23,6 +23,14 @@ Preconditions:
         der_list_poll_seconds: 60
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
+    - type: create-der-program
+      parameters:         
+        primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 600 # This is increased from the 27 defined in TS5573 Table 12.4.4 in order to comply with the <30s ramp specified in step c
   checks:
     - type: end-device-contents
       parameters: {}
@@ -48,11 +56,26 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - GET-DERC-ZERO
+            - WAIT-CONTROL
       - type: remove-steps
         parameters:
           steps:
             - GET-DERC-INITIAL
+  
+  WAIT-CONTROL:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 60 # Wait for the control to reach at least 50%
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-ZERO
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL
 
   # (a, b, c)
   GET-DERC-ZERO:
@@ -66,9 +89,24 @@ Steps:
           start: $(now)
           duration_seconds: 300
           opModImpLimW: 0
+      - type: enable-steps
+        parameters:
+          steps:
+            - WAIT-REACH-ZERO
       - type: remove-steps
         parameters:
           steps:
             - GET-DERC-ZERO
-          
   
+  WAIT-REACH-ZERO:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120 # Wait for the control to be polled, then to reach 0
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-REACH-ZERO
+      - type: finish-test
+        parameters: {}

--- a/cactus_test_definitions/client/procedures/LOA-02.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-02.yaml
@@ -23,6 +23,14 @@ Preconditions:
         der_list_poll_seconds: 60
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
+    - type: create-der-program
+      parameters:
+        primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 100 # Increased from the 0 efined in TS5573 Table 12.4.4 in order to observe the LOA limit changes without overriding them
+        opModExpLimW: 0
+        setGradW: 600 # This is increased from the 27 defined in TS5573 Table 12.4.4 in order to comply with the <30s ramp specified in step c
   checks:
     - type: end-device-contents
       parameters: {}
@@ -48,11 +56,26 @@ Steps:
       - type: enable-steps
         parameters:
           steps:
-            - GET-DERC-ZERO
+            - WAIT-CONTROL
       - type: remove-steps
         parameters:
           steps:
             - GET-DERC-INITIAL
+
+  WAIT-CONTROL:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 60 # Wait for the control to reach at least 50%
+    actions:
+      - type: enable-steps
+        parameters:
+          steps:
+            - GET-DERC-ZERO
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-CONTROL
 
   # (a, b, c)
   GET-DERC-ZERO:
@@ -66,9 +89,24 @@ Steps:
           start: $(now)
           duration_seconds: 300
           opModLoadLimW: 0
+      - type: enable-steps
+        parameters:
+          steps:
+            - WAIT-REACH-ZERO
       - type: remove-steps
         parameters:
           steps:
             - GET-DERC-ZERO
-          
-  
+
+  WAIT-REACH-ZERO:
+    event:
+      type: wait
+      parameters:
+        duration_seconds: 120 # Wait for the control to be polled, then to reach 0
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - WAIT-REACH-ZERO
+      - type: finish-test
+        parameters: {}

--- a/cactus_test_definitions/client/procedures/LOA-05.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-05.yaml
@@ -29,7 +29,12 @@ Preconditions:
     - type: create-der-program
       parameters:
         primacy: 0
-        
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 600 # This is increased from the 27 defined in TS5573 Table 12.4.4 in order to comply with the ramps specified
+
   checks:
     - type: end-device-contents
       parameters: {}
@@ -54,12 +59,12 @@ Steps:
   # NOTE - The majority of this test's validation is watching 
 
   # (a, b, c)
-  # After a short delay (to allow precondition actions to propagate subscriptions)
+  # After a short delay (to allow precondition actions to propagate subscriptions) and for device to ramp to full power
   WAIT-CREATE-DERC:
     event:
       type: wait
       parameters:
-        duration_seconds: 60
+        duration_seconds: 90
     actions:
       - type: create-der-control
         parameters:
@@ -80,11 +85,11 @@ Steps:
     event:
       type: wait
       parameters:
-        duration_seconds: 480 # enough time for the control to start, run and then finish
+        duration_seconds: 60 # enough time for the control to be received and ramp down
     actions:
       - type: remove-steps
         parameters:
           steps:
             - WAIT-TEST-FINISH
     instructions:
-      - DER should be observed ramping to and then from 0W control.
+      - DER should be observed ramping to the 0W control.

--- a/cactus_test_definitions/client/procedures/LOA-06.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-06.yaml
@@ -29,7 +29,12 @@ Preconditions:
     - type: create-der-program
       parameters:
         primacy: 0
-        
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 100 # Increased from the 0 defined in TS5573 Table 12.4.4 in order to observe the LOA limit changes without overriding them
+        opModExpLimW: 0
+        setGradW: 600 # This is increased from the 27 defined in TS5573 Table 12.4.4 in order to comply with the ramps specified
+
   checks:
     - type: end-device-contents
       parameters: {}
@@ -54,12 +59,12 @@ Steps:
   # NOTE - The majority of this test's validation is watching 
 
   # (a, b, c)
-  # After a short delay (to allow precondition actions to propagate subscriptions)
+  # After a short delay (to allow precondition actions to propagate subscriptions) and for device to ramp to full power
   WAIT-CREATE-DERC:
     event:
       type: wait
       parameters:
-        duration_seconds: 60
+        duration_seconds: 90
     actions:
       - type: create-der-control
         parameters:
@@ -80,11 +85,11 @@ Steps:
     event:
       type: wait
       parameters:
-        duration_seconds: 480 # enough time for the control to start, run and then finish
+        duration_seconds: 60 # enough time for the control to be received and ramp down
     actions:
       - type: remove-steps
         parameters:
           steps:
             - WAIT-TEST-FINISH
     instructions:
-      - DER should be observed ramping to and then from 0W control.
+      - DER should be observed ramping to the 0W control.

--- a/cactus_test_definitions/client/procedures/LOA-10.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-10.yaml
@@ -97,19 +97,19 @@ Preconditions:
     - type: set-default-der-control
       parameters:
         derp_id: 1
+        opModImpLimW: 0
         opModExpLimW: 0
-        setGradW: 167 # hundredths of a percent - this is 1.67% / second
-    # These default controls are not explicitly in the standards (SA TS5573), but we are adding here to let the 
-    # client know to keep polling at, e.g., /edev/1/derp/6/dderc, which allows step-bb-ii to work without using notifications.
-    # Previously, polling at /edev/1/derp/6/dderc was expected without any defaults being set.
+        setGradW: 167 # Altered from 27 defined in TS5573 table 12.4.4 so that control observation is not limited by slow ramping
+        # A slow ramp would interfere with many explicitly defined control times in the test
     - type: set-default-der-control
       parameters:
         derp_id: 6
-        opModExpLimW: 0 # Set to export to not interefere with import observations in witness test
-        setGradW: 167 # hundredths of a percent - this is 1.67% / second
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 167 # Altered from 27 defined in TS5573 table 12.4.4 so that control observation is not limited by slow ramping
+        # A slow ramp would interfere with many explicitly defined control times in the test
 
 Steps:
-  
   # (a, b) - Create a Default DERControl at DERP 1 - set to 30% of max
   GET-DEFAULT-DERC:
     event:

--- a/cactus_test_definitions/client/procedures/LOA-11.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-11.yaml
@@ -85,7 +85,12 @@ Preconditions:
         mup_post_seconds: 60
     - type: create-der-program
       parameters:
-        primacy: 0
+        primacy: 0  
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 600 # Altered from 27 defined in TS5573 table 12.4.4 so that control observation is not limited by slow ramping
   checks:
     - type: end-device-contents
       parameters: {}

--- a/cactus_test_definitions/client/procedures/LOA-13.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-13.yaml
@@ -23,7 +23,14 @@ Preconditions:
         der_list_poll_seconds: 60 
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
-
+    - type: create-der-program
+      parameters:
+        primacy: 0  
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 600 # Altered from 27 defined in TS5573 table 12.4.4 so that control observation is not limited by slow ramping
   checks:
     - type: end-device-contents
       parameters: {}


### PR DESCRIPTION
This PR adds default der controls to several tests. The focus of this work is on tests where changes to setGradW are made to the default controls specified in TS5573 table 12.4.4 in order to observe the controls created in the test without being overriden by a slow ramp rate. 

The CSIP-Aus Implementation Reference Group has granted permission for the test setup defaults to be altered where necessary to preserve the intent of the tests.