### PR TITLE
Default der controls pt5

### DIFF
--- a/cactus_test_definitions/client/procedures/ALT-ALL-29.yaml
+++ b/cactus_test_definitions/client/procedures/ALT-ALL-29.yaml
@@ -29,6 +29,14 @@ Preconditions:
         der_list_poll_seconds: 60
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
+    - type: create-der-program
+      parameters:
+        primacy: 0  
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 600 # Altered from 27 defined in TS5573 table 12.4.4 so that control observation is not limited by slow ramping
   checks:
     - type: end-device-contents
       parameters: {}

--- a/cactus_test_definitions/client/procedures/ALT-LOA-13.yaml
+++ b/cactus_test_definitions/client/procedures/ALT-LOA-13.yaml
@@ -23,7 +23,14 @@ Preconditions:
         der_list_poll_seconds: 60 
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
-
+    - type: create-der-program
+      parameters:
+        primacy: 0  
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 600 # Altered from 27 defined in TS5573 table 12.4.4 so that control observation is not limited by slow ramping
   checks:
     - type: end-device-contents
       parameters: {}

--- a/cactus_test_definitions/client/procedures/DRA-01.yaml
+++ b/cactus_test_definitions/client/procedures/DRA-01.yaml
@@ -22,6 +22,15 @@ Criteria:
 
 Preconditions:
   immediate_start: true # There will be no "init" phase - all interactions will be immediately logged against the test
+  actions:
+    - type: create-der-program
+      parameters:         
+        primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 27
 
 Steps:
 

--- a/cactus_test_definitions/client/procedures/DRA-01.yaml
+++ b/cactus_test_definitions/client/procedures/DRA-01.yaml
@@ -22,7 +22,15 @@ Criteria:
 
 Preconditions:
   immediate_start: true # There will be no "init" phase - all interactions will be immediately logged against the test
-  actions:
+  init_actions:
+    - type: set-comms-rate
+      parameters:
+        dcap_poll_seconds: 60
+        edev_list_poll_seconds: 60
+        fsa_list_poll_seconds: 60
+        der_list_poll_seconds: 60
+        derp_list_poll_seconds: 60
+        mup_post_seconds: 60
     - type: create-der-program
       parameters:         
         primacy: 0

--- a/cactus_test_definitions/client/procedures/DRA-02.yaml
+++ b/cactus_test_definitions/client/procedures/DRA-02.yaml
@@ -17,8 +17,13 @@ Criteria:
 Preconditions:
   init_actions:
     - type: create-der-program
-      parameters:
+      parameters:         
         primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 100 # Altered from the 0 defined in TS5573 in order to observe DER Control effects
+        opModExpLimW: 100 # Altered from the 0 defined in TS5573 in order to observe DER Control effects
+        setGradW: 27
   checks:
     - type: end-device-contents
       parameters: {}

--- a/cactus_test_definitions/client/procedures/DRA-02.yaml
+++ b/cactus_test_definitions/client/procedures/DRA-02.yaml
@@ -16,6 +16,14 @@ Criteria:
 
 Preconditions:
   init_actions:
+    - type: set-comms-rate
+      parameters:
+        dcap_poll_seconds: 60
+        edev_list_poll_seconds: 60
+        fsa_list_poll_seconds: 60
+        der_list_poll_seconds: 60
+        derp_list_poll_seconds: 60
+        mup_post_seconds: 60
     - type: create-der-program
       parameters:         
         primacy: 0

--- a/cactus_test_definitions/client/procedures/DRD-01.yaml
+++ b/cactus_test_definitions/client/procedures/DRD-01.yaml
@@ -10,9 +10,14 @@ TargetVersions:
 
 Preconditions:
   init_actions:
-      - type: create-der-program
-        parameters:
-          primacy: 0
+    - type: create-der-program
+      parameters:         
+        primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 100 # Altered from the 0 defined in TS5573 in order to observe DER Control effects
+        opModExpLimW: 100 # Altered from the 0 defined in TS5573 in order to observe DER Control effects
+        setGradW: 27
   checks:
     - type: end-device-contents
       parameters: {}

--- a/cactus_test_definitions/client/procedures/DRD-01.yaml
+++ b/cactus_test_definitions/client/procedures/DRD-01.yaml
@@ -10,6 +10,14 @@ TargetVersions:
 
 Preconditions:
   init_actions:
+    - type: set-comms-rate
+      parameters:
+        dcap_poll_seconds: 60
+        edev_list_poll_seconds: 60
+        fsa_list_poll_seconds: 60
+        der_list_poll_seconds: 60
+        derp_list_poll_seconds: 60
+        mup_post_seconds: 60
     - type: create-der-program
       parameters:         
         primacy: 0
@@ -23,11 +31,6 @@ Preconditions:
       parameters: {}
     - type: der-settings-contents
       parameters: {}
-  actions:
-    - type: set-comms-rate
-      parameters:
-        der_list_poll_seconds: 60
-        derp_list_poll_seconds: 60
 
 Criteria:
   checks:

--- a/cactus_test_definitions/client/procedures/DRG-01.yaml
+++ b/cactus_test_definitions/client/procedures/DRG-01.yaml
@@ -10,6 +10,14 @@ TargetVersions:
 
 Preconditions:
   init_actions:
+    - type: set-comms-rate
+      parameters:
+        dcap_poll_seconds: 60
+        edev_list_poll_seconds: 60
+        fsa_list_poll_seconds: 60
+        der_list_poll_seconds: 60
+        derp_list_poll_seconds: 60
+        mup_post_seconds: 60
     - type: create-der-program
       parameters:
         primacy: 0
@@ -23,11 +31,6 @@ Preconditions:
       parameters: {}
     - type: der-settings-contents
       parameters: {}
-  actions:
-    - type: set-comms-rate
-      parameters:
-        der_list_poll_seconds: 60
-        derp_list_poll_seconds: 60
   instructions:
     - The controlled device should be connected to the grid and generating 90% (+/- 5%) of its nameplate rating maximum.
 

--- a/cactus_test_definitions/client/procedures/DRG-01.yaml
+++ b/cactus_test_definitions/client/procedures/DRG-01.yaml
@@ -10,9 +10,14 @@ TargetVersions:
 
 Preconditions:
   init_actions:
-      - type: create-der-program
-        parameters:
-          primacy: 0
+    - type: create-der-program
+      parameters:
+        primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 100 # Altered from the 0 defined in TS5573 in order to observe DER Control effects
+        opModExpLimW: 100 # Altered from the 0 defined in TS5573 in order to observe DER Control effects
+        setGradW: 27
   checks:
     - type: end-device-contents
       parameters: {}

--- a/cactus_test_definitions/client/procedures/DRL-01.yaml
+++ b/cactus_test_definitions/client/procedures/DRL-01.yaml
@@ -10,6 +10,14 @@ TargetVersions:
 
 Preconditions:
   init_actions:
+    - type: set-comms-rate
+      parameters:
+        dcap_poll_seconds: 60
+        edev_list_poll_seconds: 60
+        fsa_list_poll_seconds: 60
+        der_list_poll_seconds: 60
+        derp_list_poll_seconds: 60
+        mup_post_seconds: 60
     - type: create-der-program
       parameters:
         primacy: 0
@@ -23,11 +31,6 @@ Preconditions:
       parameters: {}
     - type: der-settings-contents
       parameters: {}
-  actions:
-    - type: set-comms-rate
-      parameters:
-        der_list_poll_seconds: 60
-        derp_list_poll_seconds: 60
   instructions:
     - The controlled device should be connected to the grid and consuming 90% (+/- 5%) of its nameplate rating maximum.
 

--- a/cactus_test_definitions/client/procedures/DRL-01.yaml
+++ b/cactus_test_definitions/client/procedures/DRL-01.yaml
@@ -10,9 +10,14 @@ TargetVersions:
 
 Preconditions:
   init_actions:
-      - type: create-der-program
-        parameters:
-          primacy: 0
+    - type: create-der-program
+      parameters:
+        primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 100 # Altered from the 0 defined in TS5573 in order to observe DER Control effects
+        opModExpLimW: 100 # Altered from the 0 defined in TS5573 in order to observe DER Control effects
+        setGradW: 27
   checks:
     - type: end-device-contents
       parameters: {}
@@ -333,4 +338,3 @@ Steps:
             - WAIT-DERC-4
       - type: finish-test
         parameters: {}
-

--- a/cactus_test_definitions/client/procedures/PRC-01.yaml
+++ b/cactus_test_definitions/client/procedures/PRC-01.yaml
@@ -32,7 +32,14 @@ Preconditions:
         mup_post_seconds: 60
         tp_list_poll_seconds: 300
         tti_list_poll_seconds: 60
-        
+    - type: create-der-program
+      parameters:         
+        primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 27
   checks:
     - type: end-device-contents
       parameters: {}

--- a/cactus_test_definitions/client/procedures/PRC-02.yaml
+++ b/cactus_test_definitions/client/procedures/PRC-02.yaml
@@ -24,7 +24,14 @@ Preconditions:
         mup_post_seconds: 60
         tp_list_poll_seconds: 60
         tti_list_poll_seconds: 60
-        
+    - type: create-der-program
+      parameters:         
+        primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 27
   checks:
     - type: end-device-contents
       parameters: {}

--- a/cactus_test_definitions/client/procedures/PRC-03.yaml
+++ b/cactus_test_definitions/client/procedures/PRC-03.yaml
@@ -51,7 +51,14 @@ Preconditions:
         mup_post_seconds: 60
         tp_list_poll_seconds: 120
         tti_list_poll_seconds: 240
-        
+    - type: create-der-program
+      parameters:         
+        primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 27
   checks:
     - type: end-device-contents
       parameters: {}

--- a/cactus_test_definitions/client/procedures/PRC-04.yaml
+++ b/cactus_test_definitions/client/procedures/PRC-04.yaml
@@ -55,7 +55,14 @@ Preconditions:
         mup_post_seconds: 60
         tp_list_poll_seconds: 60
         tti_list_poll_seconds: 60
-        
+    - type: create-der-program
+      parameters:         
+        primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 27
   checks:
     - type: end-device-contents
       parameters: {}

--- a/cactus_test_definitions/client/procedures/PRC-05.yaml
+++ b/cactus_test_definitions/client/procedures/PRC-05.yaml
@@ -39,7 +39,14 @@ Preconditions:
         mup_post_seconds: 60
         tp_list_poll_seconds: 60 # This will be revised up at the first poll
         tti_list_poll_seconds: 60
-        
+    - type: create-der-program
+      parameters:         
+        primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 27
   checks:
     - type: end-device-contents
       parameters: {}

--- a/cactus_test_definitions/client/procedures/SDVN-01.yaml
+++ b/cactus_test_definitions/client/procedures/SDVN-01.yaml
@@ -33,6 +33,14 @@ Preconditions:
         der_list_poll_seconds: 60
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
+    - type: create-der-program
+      parameters:         
+        primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 27
     - type: create-wellknown-route
       parameters:
         version: "https://csipaus.org/ns/v99.99"

--- a/cactus_test_definitions/client/procedures/STO-01.yaml
+++ b/cactus_test_definitions/client/procedures/STO-01.yaml
@@ -27,7 +27,14 @@ Preconditions:
         der_list_poll_seconds: 60
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
-
+    - type: create-der-program
+      parameters:         
+        primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 27
   checks:
     - type: end-device-contents
       parameters: {}

--- a/cactus_test_definitions/client/procedures/STO-02.yaml
+++ b/cactus_test_definitions/client/procedures/STO-02.yaml
@@ -18,6 +18,14 @@ Preconditions:
         der_list_poll_seconds: 60
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
+    - type: create-der-program
+      parameters:         
+        primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 27
 
 Criteria:
   checks:

--- a/cactus_test_definitions/client/procedures/STO-04.yaml
+++ b/cactus_test_definitions/client/procedures/STO-04.yaml
@@ -27,7 +27,14 @@ Preconditions:
         der_list_poll_seconds: 60
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
-
+    - type: create-der-program
+      parameters:         
+        primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 27
   checks:
     - type: end-device-contents
       parameters: {}

--- a/cactus_test_definitions/client/procedures/STO-05.yaml
+++ b/cactus_test_definitions/client/procedures/STO-05.yaml
@@ -17,7 +17,14 @@ Preconditions:
         der_list_poll_seconds: 60
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
-
+    - type: create-der-program
+      parameters:         
+        primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: 0
+        setGradW: 27
   checks:
     - type: end-device-contents
       parameters: {}

--- a/tests/unit/client/test_test_procedures.py
+++ b/tests/unit/client/test_test_procedures.py
@@ -70,13 +70,26 @@ def test_error_on_extra_key():
         parse_test_procedure(yaml_contents)
 
 
+# Test procedures that are intentionally exempt from requiring create-der-program/set-default-der-control in
+# their preconditions, along with the reason why.
+PRECONDITION_DER_PROGRAM_AND_CONTROL_EXCEPTIONS = {
+    TestProcedureId.P_01: "Provisional test - Does not improve the test, not part of TS5573 requirements.",
+    TestProcedureId.P_02: "Provisional test - Does not improve the test, not part of TS5573 requirements.",
+}
+
+
 def test_preconditions_include_der_program_and_default_der_control():
     """Every test procedure must set up a DERProgram and a default DERControl in its preconditions (as either
-    init_actions or actions) so that clients always have a well-defined default control state to fall back to."""
+    init_actions or actions) as defined in TS5573 table 12.4.4.
+
+    A small set of test procedures are exempt - see PRECONDITION_DER_PROGRAM_AND_CONTROL_EXCEPTIONS."""
 
     all_tps = get_all_test_procedures()
     missing: dict[str, set[str]] = {}
     for tp_id, tp in all_tps.items():
+        if tp_id in PRECONDITION_DER_PROGRAM_AND_CONTROL_EXCEPTIONS:
+            continue
+
         preconditions = tp.preconditions
         precondition_actions: list[Action] = []
         if preconditions is not None:

--- a/tests/unit/client/test_test_procedures.py
+++ b/tests/unit/client/test_test_procedures.py
@@ -6,6 +6,7 @@ import pytest
 from assertical.asserts.type import assert_dict_type
 from dataclass_wizard.errors import UnknownKeysError
 
+from cactus_test_definitions.client.actions import Action
 from cactus_test_definitions.client.test_procedures import (
     TestProcedure,
     TestProcedureId,
@@ -67,6 +68,27 @@ def test_error_on_extra_key():
 
     with pytest.raises(UnknownKeysError):
         parse_test_procedure(yaml_contents)
+
+
+def test_preconditions_include_der_program_and_default_der_control():
+    """Every test procedure must set up a DERProgram and a default DERControl in its preconditions (as either
+    init_actions or actions) so that clients always have a well-defined default control state to fall back to."""
+
+    all_tps = get_all_test_procedures()
+    missing: dict[str, set[str]] = {}
+    for tp_id, tp in all_tps.items():
+        preconditions = tp.preconditions
+        precondition_actions: list[Action] = []
+        if preconditions is not None:
+            precondition_actions = (preconditions.init_actions or []) + (preconditions.actions or [])
+        action_types = {a.type for a in precondition_actions}
+
+        required = {"create-der-program", "set-default-der-control"}
+        missing_types = required - action_types
+        if missing_types:
+            missing[tp_id] = missing_types
+
+    assert not missing, f"Test procedures missing required precondition actions: {missing}"
 
 
 def test_TestProcedures_action_parameter_types():


### PR DESCRIPTION
Do this one last - includes a test that default controls and programs are created in test preconditions so we dont miss any.
We will need the other PR's merged before that test will pass.

Includes the v1.3 tests which could probably use some checking.