### PR TITLE
poll_rate_list_endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ checks:
 | `subscription-contents` | `subscribed_resource: str` | True if a subscription to `subscribed_resource` has been created | 
 | `readings-der-stored-energy` | `minimum_count: int/none` `minimum_level: float/none` `maximum_level: float/none` `window_seconds: uint/none` | True if any MirrorUsagePoint has a MirrorMeterReading for DER stored energy with `minimum_count` entries and/or readings all above and/or below `minimum_level`/`maximum_level` respectively; optionally for `window_seconds` |
 | `resource-requests` | `resources: list[CSIPAusResource]` `minimum_count: int/None` `maximum_count: int/None` | True if the client has made requests to the nominated `CSIPResource` the requisite number of times. | 
+| `all-polls-at-correct-time` | `endpoints: list[str]` `poll_interval_seconds: int` `request_type_str: str` | True if every request of type `request_type_str` (e.g. `GET`/`POST`) to each of the nominated `endpoints` (e.g. `["/dcap", "/edev"]`) arrived at intervals matching `poll_interval_seconds`. `endpoints` supports a `*` wildcard (e.g. `/mup/*`), with each matched concrete path (e.g. `/mup/2`, `/mup/3`) checked independently. Timing uses tolerance windows rather than exact spacing: a gap greater than 1.5x the interval counts as a missed poll (tolerating at most one miss per 5x-interval window), and over-polling is capped per 3x-interval window. |
 
 
 #### Hexbinary Parameters for Bitwise Operations

--- a/cactus_test_definitions/client/checks.py
+++ b/cactus_test_definitions/client/checks.py
@@ -121,7 +121,7 @@ CHECK_PARAMETER_SCHEMA: dict[str, dict[str, ParameterSchema]] = {
         ),  # Default is True - If True, assert the response exists. Otherwise assert it does NOT exist
     },
     "all-polls-at-correct-time": {
-        "endpoint": ParameterSchema(True, ParameterType.String),  # e.g. /dcap
+        "endpoints": ParameterSchema(True, ParameterType.ListString),  # e.g. ["/dcap"] or ["/derp", "/derc"]
         "poll_interval_seconds": ParameterSchema(True, ParameterType.Integer),
         "request_type_str": ParameterSchema(True, ParameterType.String),  # e.g. GET, POST
     },

--- a/cactus_test_definitions/client/procedures/ALL-06.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-06.yaml
@@ -121,6 +121,23 @@ Steps:
       type: wait
       parameters:
         duration_seconds: 180 # Wait for at least 3 sets of readings to arrive (with post rate 60 seconds)
+      checks:
+        - type: all-polls-at-correct-time
+          parameters:
+            endpoints:
+              - /dcap
+              - /edev
+              - /edev/1/fsa
+              - /edev/1/der
+              - /edev/1/fsa/1/derp
+            poll_interval_seconds: 60
+            request_type_str: GET
+        - type: all-polls-at-correct-time
+          parameters:
+            endpoints:
+              - /mup
+            poll_interval_seconds: 60
+            request_type_str: POST
     actions:
       - type: remove-steps
         parameters:

--- a/cactus_test_definitions/client/procedures/ALL-06.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-06.yaml
@@ -130,14 +130,10 @@ Steps:
               - /edev/1/fsa
               - /edev/1/der
               - /edev/1/fsa/1/derp
-            poll_interval_seconds: 60
-            request_type_str: GET
-        - type: all-polls-at-correct-time
-          parameters:
-            endpoints:
+              - /edev/1/derp/1/dderc
               - /mup
             poll_interval_seconds: 60
-            request_type_str: POST
+            request_type_str: GET
     actions:
       - type: remove-steps
         parameters:

--- a/cactus_test_definitions/client/procedures/ALL-21.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-21.yaml
@@ -226,6 +226,23 @@ Steps:
       type: wait
       parameters:
         duration_seconds: 1500 # 25 minutes
+      checks:
+        - type: all-polls-at-correct-time
+          parameters:
+            endpoints:
+              - /dcap
+              - /edev
+              - /edev/1/fsa
+              - /edev/1/der
+              - /edev/1/fsa/1/derp
+            poll_interval_seconds: 60
+            request_type_str: GET
+        - type: all-polls-at-correct-time
+          parameters:
+            endpoints:
+              - /mup
+            poll_interval_seconds: 60
+            request_type_str: POST
     actions:
       - type: remove-steps
         parameters:

--- a/cactus_test_definitions/client/procedures/ALL-21.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-21.yaml
@@ -235,14 +235,10 @@ Steps:
               - /edev/1/fsa
               - /edev/1/der
               - /edev/1/fsa/1/derp
-            poll_interval_seconds: 60
-            request_type_str: GET
-        - type: all-polls-at-correct-time
-          parameters:
-            endpoints:
+              - /edev/1/derp/1/dderc
               - /mup
             poll_interval_seconds: 60
-            request_type_str: POST
+            request_type_str: GET
     actions:
       - type: remove-steps
         parameters:

--- a/cactus_test_definitions/client/procedures/ALL-24.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-24.yaml
@@ -129,6 +129,23 @@ Steps:
       type: wait
       parameters:
         duration_seconds: 180
+    checks:
+        - type: all-polls-at-correct-time
+          parameters:
+            endpoints:
+              - /dcap
+              - /edev
+              - /edev/1/fsa
+              - /edev/1/der
+              - /edev/1/fsa/1/derp
+            poll_interval_seconds: 120
+            request_type_str: GET
+        - type: all-polls-at-correct-time
+          parameters:
+            endpoints:
+              - /mup
+            poll_interval_seconds: 60
+            request_type_str: POST
     actions:
       - type: remove-steps
         parameters:

--- a/cactus_test_definitions/client/procedures/ALL-24.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-24.yaml
@@ -138,6 +138,7 @@ Steps:
                 - /edev/1/fsa
                 - /edev/1/der
                 - /edev/1/fsa/1/derp
+                - /edev/1/derp/1/dderc
               poll_interval_seconds: 120
               request_type_str: GET
           - type: all-polls-at-correct-time
@@ -145,7 +146,7 @@ Steps:
               endpoints:
                 - /mup
               poll_interval_seconds: 60
-              request_type_str: POST
+              request_type_str: GET
     actions:
       - type: remove-steps
         parameters:

--- a/cactus_test_definitions/client/procedures/ALL-24.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-24.yaml
@@ -129,23 +129,23 @@ Steps:
       type: wait
       parameters:
         duration_seconds: 180
-    checks:
-        - type: all-polls-at-correct-time
-          parameters:
-            endpoints:
-              - /dcap
-              - /edev
-              - /edev/1/fsa
-              - /edev/1/der
-              - /edev/1/fsa/1/derp
-            poll_interval_seconds: 120
-            request_type_str: GET
-        - type: all-polls-at-correct-time
-          parameters:
-            endpoints:
-              - /mup
-            poll_interval_seconds: 60
-            request_type_str: POST
+      checks:
+          - type: all-polls-at-correct-time
+            parameters:
+              endpoints:
+                - /dcap
+                - /edev
+                - /edev/1/fsa
+                - /edev/1/der
+                - /edev/1/fsa/1/derp
+              poll_interval_seconds: 120
+              request_type_str: GET
+          - type: all-polls-at-correct-time
+            parameters:
+              endpoints:
+                - /mup
+              poll_interval_seconds: 60
+              request_type_str: POST
     actions:
       - type: remove-steps
         parameters:


### PR DESCRIPTION
Lets us use lists of endpoints rather than separate checks for each

Added to 2 tests for now (the ones we originally added the check to) PLUS ALL-24 because it is an example of a non-60s poll-rate and has two different poll rates set on different endpoints during the test.

Open to adding way more, or removing these depending how you want to roll this out. 