### PR TITLE
Fix LOA-04 default power limits

### DIFF
--- a/cactus_test_definitions/client/procedures/LOA-04.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-04.yaml
@@ -29,10 +29,10 @@ Preconditions:
         primacy: 0
     - type: set-default-der-control
       parameters:
-      # The import and export values are specified as 0 in TS5573 Table 12.4.4. They have been altered for this test so
-      # that a device can follow the load limits set in this test without being overridden.
-        opModImpLimW: 100
-        opModExpLimW: 100
+      # The import and export values are specified as 0 in TS5573 Table 12.4.4. Set them to the site's absolute
+      # limits so that the load limit under test is not overridden by a more restrictive 100 W limit.
+        opModImpLimW: $(maxImportW)
+        opModExpLimW: $(maxExportW)
         setGradW: 167 # Increased from 27 in Table 12.4.4 to avoid two 13 minute waits without altering the test intent
   checks:
     - type: end-device-contents


### PR DESCRIPTION
## Problem

LOA-04 intends the default import/export limits to avoid overriding the load limit under test. The current literal values are serialized as IEEE ActivePower `100 W`, so they constrain a device to about 100 W instead of allowing the expected 30% load limit.

## Change

Use `$(maxImportW)` and `$(maxExportW)`, matching the absolute-site-limit pattern already used by sibling procedures.

## Validation

- Parsed the updated YAML and confirmed both variables are preserved.
- `tests/unit/client/test_validate.py` passed under Python 3.12.
- `tests/unit/client/test_test_procedures.py` passed under Python 3.12.
- Live CACTUS Run 58685 completed 8/8 and was finalised, but the device was physically limited to about 0.1 kW instead of the expected 18 kW, confirming the issue.