### PR TITLE
Fix init actions not resolving device limits

### DIFF
--- a/cactus_test_definitions/client/procedures/ALL-06.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-06.yaml
@@ -43,9 +43,11 @@ Preconditions:
     - type: set-default-der-control
       parameters:
       # The import and export values are specified as 0 in TS5573 Table 12.4.4. They have been altered for this test so
-      # that a device can see the difference when the active control is set to 0.
-        opModImpLimW: $(maxImportW)
-        opModExpLimW: $(maxExportW)
+      # that a device can see the difference when the active control is set to 0. A per-device value (e.g.
+      # $(maxImportW)) can't be resolved here - init_actions fire before the client under test has registered - so
+      # a large static value is used instead.
+        opModImpLimW: 200000
+        opModExpLimW: 200000
         setGradW: 27
   instructions:
     - Connect a test load electrically in parallel with the DER.

--- a/cactus_test_definitions/client/procedures/ALL-08.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-08.yaml
@@ -26,6 +26,13 @@ Preconditions:
     - type: create-der-program
       parameters:
         primacy: 0
+  checks:
+    - type: end-device-contents
+      parameters: {}
+    - type: der-status-contents
+      parameters:
+        operationalModeStatus: 2
+  actions:
     - type: set-default-der-control
       parameters:
       # The import and export values are specified as 0 in TS5573 Table 12.4.4. These have been altered for this test so
@@ -33,12 +40,6 @@ Preconditions:
         opModImpLimW: $(maxImportW)
         opModExpLimW: $(maxExportW)
         setGradW: 27
-  checks:
-    - type: end-device-contents
-      parameters: {}
-    - type: der-status-contents
-      parameters: 
-        operationalModeStatus: 2
   instructions:
     - DER shall be generating or consuming at least 50% of the DER's active power rating.
       

--- a/cactus_test_definitions/client/procedures/DRA-02.yaml
+++ b/cactus_test_definitions/client/procedures/DRA-02.yaml
@@ -25,18 +25,19 @@ Preconditions:
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
     - type: create-der-program
-      parameters:         
-        primacy: 0
-    - type: set-default-der-control
       parameters:
-        opModImpLimW: $(maxImportW) # Altered from the 0 defined in TS5573 in order to observe DER Control effects
-        opModExpLimW: $(maxExportW) # Altered from the 0 defined in TS5573 in order to observe DER Control effects
-        setGradW: 27
+        primacy: 0
   checks:
     - type: end-device-contents
       parameters: {}
     - type: der-settings-contents
       parameters: {}
+  actions:
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: $(maxImportW) # Altered from the 0 defined in TS5573 in order to observe DER Control effects
+        opModExpLimW: $(maxExportW) # Altered from the 0 defined in TS5573 in order to observe DER Control effects
+        setGradW: 27
   instructions:
     - The controlled device is connected to the grid and consuming/generating power of at least 50% of its nameplate rating
       

--- a/cactus_test_definitions/client/procedures/DRD-01.yaml
+++ b/cactus_test_definitions/client/procedures/DRD-01.yaml
@@ -19,18 +19,19 @@ Preconditions:
         derp_list_poll_seconds: 60
         mup_post_seconds: 60
     - type: create-der-program
-      parameters:         
-        primacy: 0
-    - type: set-default-der-control
       parameters:
-        opModImpLimW: $(maxImportW) # Altered from the 0 defined in TS5573 in order to observe DER Control effects
-        opModExpLimW: $(maxExportW) # Altered from the 0 defined in TS5573 in order to observe DER Control effects
-        setGradW: 27
+        primacy: 0
   checks:
     - type: end-device-contents
       parameters: {}
     - type: der-settings-contents
       parameters: {}
+  actions:
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: $(maxImportW) # Altered from the 0 defined in TS5573 in order to observe DER Control effects
+        opModExpLimW: $(maxExportW) # Altered from the 0 defined in TS5573 in order to observe DER Control effects
+        setGradW: 27
 
 Criteria:
   checks:

--- a/cactus_test_definitions/client/procedures/DRG-01.yaml
+++ b/cactus_test_definitions/client/procedures/DRG-01.yaml
@@ -21,16 +21,17 @@ Preconditions:
     - type: create-der-program
       parameters:
         primacy: 0
-    - type: set-default-der-control
-      parameters:
-        opModImpLimW: $(maxImportW) # Altered from the 0 defined in TS5573 in order to observe DER Control effects
-        opModExpLimW: $(maxExportW) # Altered from the 0 defined in TS5573 in order to observe DER Control effects
-        setGradW: 27
   checks:
     - type: end-device-contents
       parameters: {}
     - type: der-settings-contents
       parameters: {}
+  actions:
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: $(maxImportW) # Altered from the 0 defined in TS5573 in order to observe DER Control effects
+        opModExpLimW: $(maxExportW) # Altered from the 0 defined in TS5573 in order to observe DER Control effects
+        setGradW: 27
   instructions:
     - The controlled device should be connected to the grid and generating 90% (+/- 5%) of its nameplate rating maximum.
 

--- a/cactus_test_definitions/client/procedures/DRL-01.yaml
+++ b/cactus_test_definitions/client/procedures/DRL-01.yaml
@@ -21,16 +21,17 @@ Preconditions:
     - type: create-der-program
       parameters:
         primacy: 0
-    - type: set-default-der-control
-      parameters:
-        opModImpLimW: $(maxImportW) # Altered from the 0 defined in TS5573 in order to observe DER Control effects
-        opModExpLimW: $(maxExportW) # Altered from the 0 defined in TS5573 in order to observe DER Control effects
-        setGradW: 27
   checks:
     - type: end-device-contents
       parameters: {}
     - type: der-settings-contents
       parameters: {}
+  actions:
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: $(maxImportW) # Altered from the 0 defined in TS5573 in order to observe DER Control effects
+        opModExpLimW: $(maxExportW) # Altered from the 0 defined in TS5573 in order to observe DER Control effects
+        setGradW: 27
   instructions:
     - The controlled device should be connected to the grid and consuming 90% (+/- 5%) of its nameplate rating maximum.
 

--- a/cactus_test_definitions/client/procedures/GEN-02.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-02.yaml
@@ -27,17 +27,17 @@ Preconditions:
     - type: create-der-program
       parameters:
         primacy: 0
-    - type: set-default-der-control
-      parameters:
-        opModImpLimW: 0
-        opModExpLimW: $(maxExportW) # Increased from the 0 efined in TS5573 Table 12.4.4 in order to observe the GEN limit changes without overriding them
-        setGradW: 600 # This is increased from the 27 defined in TS5573 Table 12.4.4 in order to comply with the <30s ramp specified in step c
   checks:
     - type: end-device-contents
       parameters: {}
     - type: der-settings-contents
       parameters: {}
   actions:
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: $(maxExportW) # Increased from the 0 efined in TS5573 Table 12.4.4 in order to observe the GEN limit changes without overriding them
+        setGradW: 600 # This is increased from the 27 defined in TS5573 Table 12.4.4 in order to comply with the <30s ramp specified in step c
     - type: create-der-control
       parameters:
         start: $(now)

--- a/cactus_test_definitions/client/procedures/GEN-04.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-04.yaml
@@ -27,6 +27,12 @@ Preconditions:
     - type: create-der-program
       parameters:
         primacy: 0
+  checks:
+    - type: end-device-contents
+      parameters: {}
+    - type: der-settings-contents
+      parameters: {}
+  actions:
     - type: set-default-der-control
       parameters:
       # The import and export values are specified as 0 in TS5573 Table 12.4.4. They have been altered for this test so
@@ -34,12 +40,6 @@ Preconditions:
         opModImpLimW: $(maxImportW)
         opModExpLimW: $(maxExportW)
         setGradW: 167 # Increased from 27 in Table 12.4.4 to avoid two 13 minute waits without altering the test intent
-  checks:
-    - type: end-device-contents
-      parameters: {}
-    - type: der-settings-contents
-      parameters: {}
-  actions:
     - type: create-der-control
       parameters:
         start: $(now)

--- a/cactus_test_definitions/client/procedures/GEN-06.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-06.yaml
@@ -29,11 +29,6 @@ Preconditions:
     - type: create-der-program
       parameters:
         primacy: 0
-    - type: set-default-der-control
-      parameters:
-        opModImpLimW: 0
-        opModExpLimW: $(maxExportW) # Increased from the 0 defined in TS5573 Table 12.4.4 in order to observe the GEN limit changes without overriding them
-        setGradW: 600 # This is increased from the 27 defined in TS5573 Table 12.4.4 in order to comply with the ramps specified
 
   checks:
     - type: end-device-contents
@@ -45,6 +40,11 @@ Preconditions:
         subscribed_resource: /edev/1/derp/1/derc
 
   actions:
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: 0
+        opModExpLimW: $(maxExportW) # Increased from the 0 defined in TS5573 Table 12.4.4 in order to observe the GEN limit changes without overriding them
+        setGradW: 600 # This is increased from the 27 defined in TS5573 Table 12.4.4 in order to comply with the ramps specified
     - type: create-der-control
       parameters:
         start: $(now)

--- a/cactus_test_definitions/client/procedures/GEN-12.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-12.yaml
@@ -86,6 +86,14 @@ Preconditions:
     - type: create-der-program
       parameters:
         primacy: 0
+
+  checks:
+    - type: end-device-contents
+      parameters: {}
+    - type: der-settings-contents
+      parameters: {}
+
+  actions:
     - type: set-default-der-control
       parameters:
       # The import and export values are specified as 0 in TS5573 Table 12.4.4. They have been altered for this test so
@@ -95,12 +103,6 @@ Preconditions:
         opModImpLimW: $(maxImportW)
         opModExpLimW: $(maxExportW)
         setGradW: 600  # 6%/s which is about 17s for 100% to 0.
-
-  checks:
-    - type: end-device-contents
-      parameters: {}
-    - type: der-settings-contents
-      parameters: {}
 
 Steps:
   # CREATE DER CONTROLS (all at once to avoid gaps between controls)

--- a/cactus_test_definitions/client/procedures/LOA-02.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-02.yaml
@@ -26,17 +26,17 @@ Preconditions:
     - type: create-der-program
       parameters:
         primacy: 0
-    - type: set-default-der-control
-      parameters:
-        opModImpLimW: $(maxImportW) # Increased from the 0 efined in TS5573 Table 12.4.4 in order to observe the LOA limit changes without overriding them
-        opModExpLimW: 0
-        setGradW: 600 # This is increased from the 27 defined in TS5573 Table 12.4.4 in order to comply with the <30s ramp specified in step c
   checks:
     - type: end-device-contents
       parameters: {}
     - type: der-settings-contents
       parameters: {}
   actions:
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: $(maxImportW) # Increased from the 0 efined in TS5573 Table 12.4.4 in order to observe the LOA limit changes without overriding them
+        opModExpLimW: 0
+        setGradW: 600 # This is increased from the 27 defined in TS5573 Table 12.4.4 in order to comply with the <30s ramp specified in step c
     - type: create-der-control
       parameters:
         start: $(now)

--- a/cactus_test_definitions/client/procedures/LOA-04.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-04.yaml
@@ -27,6 +27,12 @@ Preconditions:
     - type: create-der-program
       parameters:
         primacy: 0
+  checks:
+    - type: end-device-contents
+      parameters: {}
+    - type: der-settings-contents
+      parameters: {}
+  actions:
     - type: set-default-der-control
       parameters:
       # The import and export values are specified as 0 in TS5573 Table 12.4.4. Set them to the site's absolute
@@ -34,12 +40,6 @@ Preconditions:
         opModImpLimW: $(maxImportW)
         opModExpLimW: $(maxExportW)
         setGradW: 167 # Increased from 27 in Table 12.4.4 to avoid two 13 minute waits without altering the test intent
-  checks:
-    - type: end-device-contents
-      parameters: {}
-    - type: der-settings-contents
-      parameters: {}
-  actions:
     - type: create-der-control
       parameters:
         start: $(now)

--- a/cactus_test_definitions/client/procedures/LOA-06.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-06.yaml
@@ -29,11 +29,6 @@ Preconditions:
     - type: create-der-program
       parameters:
         primacy: 0
-    - type: set-default-der-control
-      parameters:
-        opModImpLimW: $(maxImportW) # Increased from the 0 defined in TS5573 Table 12.4.4 in order to observe the LOA limit changes without overriding them
-        opModExpLimW: 0
-        setGradW: 600 # This is increased from the 27 defined in TS5573 Table 12.4.4 in order to comply with the ramps specified
 
   checks:
     - type: end-device-contents
@@ -45,6 +40,11 @@ Preconditions:
         subscribed_resource: /edev/1/derp/1/derc
 
   actions:
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: $(maxImportW) # Increased from the 0 defined in TS5573 Table 12.4.4 in order to observe the LOA limit changes without overriding them
+        opModExpLimW: 0
+        setGradW: 600 # This is increased from the 27 defined in TS5573 Table 12.4.4 in order to comply with the ramps specified
     - type: create-der-control
       parameters:
         start: $(now)

--- a/cactus_test_definitions/client/procedures/LOA-12.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-12.yaml
@@ -86,6 +86,14 @@ Preconditions:
     - type: create-der-program
       parameters:
         primacy: 0
+
+  checks:
+    - type: end-device-contents
+      parameters: {}
+    - type: der-settings-contents
+      parameters: {}
+
+  actions:
     - type: set-default-der-control
       parameters:
       # The import and export values are specified as 0 in TS5573 Table 12.4.4. They have been altered for this test so
@@ -95,12 +103,6 @@ Preconditions:
         opModImpLimW: $(maxImportW)
         opModExpLimW: $(maxExportW)
         setGradW: 600  # 6%/s which is about 17s for 100% to 0.
-
-  checks:
-    - type: end-device-contents
-      parameters: {}
-    - type: der-settings-contents
-      parameters: {}
 
 Steps:
   # CREATE DER CONTROLS (all at once to avoid gaps between controls)

--- a/cactus_test_definitions/client/validate.py
+++ b/cactus_test_definitions/client/validate.py
@@ -6,11 +6,40 @@ from cactus_test_definitions.client.test_procedures import (
     TestProcedureId,
 )
 from cactus_test_definitions.errors import TestProcedureDefinitionError
-from cactus_test_definitions.variable_expressions import BaseExpression
+from cactus_test_definitions.variable_expressions import Expression, NamedVariable, NamedVariableType
 
 # Action types whose implementation looks up the "active" EndDevice/Site under test
 # (e.g. create_der_control), can't go in init_actions
 ACTIONS_REQUIRING_REGISTERED_END_DEVICE = {"create-der-control"}
+
+# NamedVariableType members that don't depend on any state the client under test provides - these are safe to use
+# anywhere, including init_actions (which run immediately on /initialise, before any client interaction).
+# Deliberately an allowlist rather than a blocklist of "unsafe" variables: every OTHER NamedVariableType (including
+# ones added in future, eg new DERSETTING_*/DERCAPABILITY_* entries) is rejected in init_actions by default, until
+# someone explicitly proves it's safe by adding it here
+NAMED_VARIABLES_SAFE_IN_INIT_ACTIONS = {
+    NamedVariableType.NOW,
+    NamedVariableType.NOW_DAY,
+    NamedVariableType.NOW_HOUR,
+    NamedVariableType.NMI_1,
+    NamedVariableType.NMI_2,
+    NamedVariableType.RANDURI_1,
+    NamedVariableType.RANDURI_2,
+    NamedVariableType.RANDURI_3,
+}
+
+
+def _references_unsafe_named_variable(value: object) -> bool:
+    """Recursively checks a (possibly parsed) parameter value for a NamedVariable that isn't explicitly known-safe
+    for use in init_actions (ie: it may depend on client/device state that can't exist until after the client under
+    test has registered)."""
+    if isinstance(value, NamedVariable):
+        return value.variable not in NAMED_VARIABLES_SAFE_IN_INIT_ACTIONS
+    if isinstance(value, Expression):
+        return _references_unsafe_named_variable(value.lhs_operand) or _references_unsafe_named_variable(
+            value.rhs_operand
+        )
+    return False
 
 
 def validate_action(
@@ -96,7 +125,20 @@ def validate_der_program_exists_before_default_control(
 def validate_init_actions_have_no_dynamic_parameters(
     test_procedure: TestProcedure, test_procedure_id: TestProcedureId
 ) -> None:
-    """init_actions fire at /initialise, so cant depend on client state ($)"""
+    """init_actions fire at /initialise, before the client under test has had any opportunity to register (eg an
+    EndDevice, DERSetting or DERCapability). So nothing in init_actions can depend on state that only exists once
+    the client has registered:
+
+    - A NamedVariable not in NAMED_VARIABLES_SAFE_IN_INIT_ACTIONS (eg $(maxImportW), $(setMaxW)) resolves at
+      test-execution-time from client-provided state and will raise UnresolvableVariableError if attempted here.
+    - Actions like create-der-control look up the "active" EndDevice/Site directly and will fail outright, even with
+      constant parameters, since no EndDevice has been registered yet.
+
+    Such actions belong in Preconditions.actions instead, which only runs once Preconditions.checks (eg
+    der-settings-contents) have passed - i.e. after the client has registered.
+
+    raises TestProcedureDefinitionError on failure
+    """
     if not test_procedure.preconditions or not test_procedure.preconditions.init_actions:
         return
 
@@ -109,11 +151,12 @@ def validate_init_actions_have_no_dynamic_parameters(
 
         for value in (action.parameters or {}).values():
             values = value if isinstance(value, list) else [value]
-            if any(isinstance(v, BaseExpression) for v in values):
+            if any(_references_unsafe_named_variable(v) for v in values):
                 raise TestProcedureDefinitionError(
-                    f"{test_procedure_id}.Precondition init_actions[{action.type}] references a $(...) expression. "
-                    "init_actions run before the client under test has registered, so nothing dynamic can be "
-                    "resolved here. Move this action to Preconditions.actions."
+                    f"{test_procedure_id}.Precondition init_actions[{action.type}] references a variable that isn't "
+                    "known-safe for init_actions. init_actions run before the client under test has registered, so "
+                    "nothing dependent on client/device state can be resolved here. Move this action to "
+                    "Preconditions.actions."
                 )
 
 

--- a/cactus_test_definitions/client/validate.py
+++ b/cactus_test_definitions/client/validate.py
@@ -6,6 +6,11 @@ from cactus_test_definitions.client.test_procedures import (
     TestProcedureId,
 )
 from cactus_test_definitions.errors import TestProcedureDefinitionError
+from cactus_test_definitions.variable_expressions import BaseExpression
+
+# Action types whose implementation looks up the "active" EndDevice/Site under test
+# (e.g. create_der_control), can't go in init_actions
+ACTIONS_REQUIRING_REGISTERED_END_DEVICE = {"create-der-control"}
 
 
 def validate_action(
@@ -88,6 +93,30 @@ def validate_der_program_exists_before_default_control(
                 )
 
 
+def validate_init_actions_have_no_dynamic_parameters(
+    test_procedure: TestProcedure, test_procedure_id: TestProcedureId
+) -> None:
+    """init_actions fire at /initialise, so cant depend on client state ($)"""
+    if not test_procedure.preconditions or not test_procedure.preconditions.init_actions:
+        return
+
+    for action in test_procedure.preconditions.init_actions:
+        if action.type in ACTIONS_REQUIRING_REGISTERED_END_DEVICE:
+            raise TestProcedureDefinitionError(
+                f"{test_procedure_id}.Precondition init_actions[{action.type}] requires an already registered "
+                "EndDevice, which can't exist yet at init_actions time. Move it to Preconditions.actions."
+            )
+
+        for value in (action.parameters or {}).values():
+            values = value if isinstance(value, list) else [value]
+            if any(isinstance(v, BaseExpression) for v in values):
+                raise TestProcedureDefinitionError(
+                    f"{test_procedure_id}.Precondition init_actions[{action.type}] references a $(...) expression. "
+                    "init_actions run before the client under test has registered, so nothing dynamic can be "
+                    "resolved here. Move this action to Preconditions.actions."
+                )
+
+
 def validate_test_procedure_checks(test_procedure: TestProcedure, test_procedure_id: TestProcedureId) -> None:
     """Validate checks of a test procedure
 
@@ -129,3 +158,4 @@ def validate_test_procedure(test_procedure: TestProcedure, test_procedure_id: Te
     validate_test_procedure_checks(test_procedure, test_procedure_id)
     validate_test_procedure_events(test_procedure, test_procedure_id)
     validate_der_program_exists_before_default_control(test_procedure, test_procedure_id)
+    validate_init_actions_have_no_dynamic_parameters(test_procedure, test_procedure_id)

--- a/tests/data/client/tp_invalid_init_actions_dynamic_parameter.yaml
+++ b/tests/data/client/tp_invalid_init_actions_dynamic_parameter.yaml
@@ -1,0 +1,26 @@
+Description: Test with a $(...) expression in Preconditions.init_actions
+Category: Registration
+Classes:
+  - A
+  - DR-A
+TargetVersions:
+  - v1.2
+Preconditions:
+  init_actions:
+    - type: create-der-program
+      parameters:
+        primacy: 0
+    - type: set-default-der-control
+      parameters:
+        opModImpLimW: $(maxImportW)
+Steps:
+  STEP1:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /dcap
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - STEP1

--- a/tests/data/client/tp_invalid_init_actions_requires_end_device.yaml
+++ b/tests/data/client/tp_invalid_init_actions_requires_end_device.yaml
@@ -1,0 +1,28 @@
+Description: Test with create-der-control (requires a registered EndDevice) in Preconditions.init_actions
+Category: Registration
+Classes:
+  - A
+  - DR-A
+TargetVersions:
+  - v1.2
+Preconditions:
+  init_actions:
+    - type: create-der-program
+      parameters:
+        primacy: 0
+    - type: create-der-control
+      parameters:
+        start: "2024-01-01T00:00:00Z"
+        duration_seconds: 300
+        opModImpLimW: 100
+Steps:
+  STEP1:
+    event:
+      type: GET-request-received
+      parameters:
+        endpoint: /dcap
+    actions:
+      - type: remove-steps
+        parameters:
+          steps:
+            - STEP1

--- a/tests/unit/client/test_validate.py
+++ b/tests/unit/client/test_validate.py
@@ -109,6 +109,8 @@ def collect_event_param_values(tp: TestProcedure, event_type: str, param_name: s
         Path("tests/data/client/tp_invalid_bad_step_enable.yaml"),
         Path("tests/data/client/tp_invalid_bad_step_remove.yaml"),
         Path("tests/data/client/tp_invalid_default_control_before_program.yaml"),
+        Path("tests/data/client/tp_invalid_init_actions_dynamic_parameter.yaml"),
+        Path("tests/data/client/tp_invalid_init_actions_requires_end_device.yaml"),
     ],
 )
 def test_TestProcedure_invalid_examples(tp_file: Path):


### PR DESCRIPTION
init actions cannot resolve client settings
add a test to ensure we dont set up parameterised init actions
ALL-06 set to a large static default limit, because of its immediate start making other default control options tricky