### PR TITLE
Add telemetry sign checks

### DIFF
--- a/cactus_test_definitions/client/checks.py
+++ b/cactus_test_definitions/client/checks.py
@@ -39,7 +39,12 @@ def factory_readings_schema() -> dict[str, Any]:
         "minimum_count": ParameterSchema(False, ParameterType.Integer),
         "minimum_level": ParameterSchema(False, ParameterType.Float),
         "maximum_level": ParameterSchema(False, ParameterType.Float),
+        # Window backwards from the time this is called. NULL means all times.
         "window_seconds": ParameterSchema(False, ParameterType.UnsignedInteger),
+        # If True - only the single most recent reading (per SiteReadingType) is checked against
+        # minimum_level/maximum_level, rather than every/windowed historical reading. Mutually exclusive with
+        # window_seconds. Suited to gating a Preconditions check on current device state.
+        "latest_reading_only": ParameterSchema(False, ParameterType.Boolean),
     }
 
 

--- a/cactus_test_definitions/client/procedures/GEN-01.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-01.yaml
@@ -12,6 +12,19 @@ Criteria:
   checks:
     - type: all-steps-complete
       parameters: {}
+    - type: readings-site-active-power
+      # site active power should never exceed its own rated export capacity
+      # site active power should always be negative during this test: with export at 50% for test start,
+      # we assume generation must be sufficient to offset any on site loads and keep site power below 0.
+      # there is also a default control with opmodimplimw=0.
+      parameters:
+        minimum_level: $(-1.05 * maxExportW)
+        maximum_level: $(0.05 * maxExportW)
+    - type: readings-der-active-power
+      # DER is assumed to act as the inverse of the site power above. 
+      parameters:
+        maximum_level: $(1.05 * maxExportW)
+        minimum_level: $(-0.05 * maxExportW)
 
 Preconditions:
   init_actions:
@@ -36,6 +49,20 @@ Preconditions:
       parameters: {}
     - type: der-settings-contents
       parameters: {}
+    - type: readings-site-active-power
+      # Gate test start on telemetry rather than trusting the out-of-band instruction below alone: confirm the
+      # site is currently exporting between 50% and 105% of the DER's rated export capacity.
+      parameters:
+        latest_reading_only: true
+        minimum_level: $(-1.05 * maxExportW)
+        maximum_level: $(-0.5 * maxExportW)
+    - type: readings-der-active-power
+      # Gate test start on telemetry rather than trusting the out-of-band instruction below alone: confirm the
+      # device is currently exporting between 50% and 105% of the DER's rated export capacity.
+      parameters:
+        latest_reading_only: true
+        maximum_level: $(1.05 * maxExportW)
+        minimum_level: $(0.5 * maxExportW)
   actions:
     - type: create-der-control
       parameters:
@@ -44,6 +71,8 @@ Preconditions:
         opModExpLimW: $(maxExportW * 2)
   instructions:
     - DER shall be generating at the connection point at least 50% of its active power rating.
+    - The test cannot be started until site telemetry is between 50 and 100% export (check the sign carefully).
+    - Device telemetry must also be sent, and is the inverse of site (check the sign carefully).
     
 Steps:
   # (precondition)

--- a/cactus_test_definitions/client/procedures/LOA-01.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-01.yaml
@@ -18,13 +18,13 @@ Criteria:
       # we assume load must be sufficient to offset any on site generation and keep site power above 0.
       # there is also a default control with opmodexplimw=0.
       parameters:
-        minimum_level: $(1.05 * maxImportW)
-        maximum_level: $(-0.05 * maxImportW)
+        maximum_level: $(1.05 * maxImportW)
+        minimum_level: $(-0.05 * maxImportW)
     - type: readings-der-active-power
       # DER is assumed to act as the inverse of the site power above. 
       parameters:
-        maximum_level: $(-1.05 * maxImportW)
-        minimum_level: $(0.05 * maxImportW)
+        minimum_level: $(-1.05 * maxImportW)
+        maximum_level: $(0.05 * maxImportW)
 
 Preconditions:
   init_actions:
@@ -54,15 +54,15 @@ Preconditions:
       # site is currently importing between 50% and 105% of the DER's rated import capacity.
       parameters:
         latest_reading_only: true
-        minimum_level: $(1.05 * maxImportW)
-        maximum_level: $(0.5 * maxImportW)
+        maximum_level: $(1.05 * maxImportW)
+        minimum_level: $(0.5 * maxImportW)
     - type: readings-der-active-power
       # Gate test start on telemetry rather than trusting the out-of-band instruction below alone: confirm the
       # device is currently importing between 50% and 105% of the DER's rated import capacity.
       parameters:
         latest_reading_only: true
-        maximum_level: $(-1.05 * maxImportW)
-        minimum_level: $(-0.5 * maxImportW)
+        minimum_level: $(-1.05 * maxImportW)
+        maximum_level: $(-0.5 * maxImportW)
   actions:
     - type: create-der-control
       parameters:

--- a/cactus_test_definitions/client/procedures/LOA-01.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-01.yaml
@@ -70,8 +70,8 @@ Preconditions:
         duration_seconds: 300
         opModImpLimW: $(maxImportW * 2)
   instructions:
-    - DER shall be importing at the connection point with at least 50% of its active power rating.
-    
+    - The test cannot be started until site telemetry is between 50 and 100% import (check the sign carefully).
+    - Device telemetry must also be sent, and is the inverse of site (check the sign carefully).
 Steps:
   # (precondition)
   GET-DERC-INITIAL:

--- a/cactus_test_definitions/client/procedures/LOA-01.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-01.yaml
@@ -70,6 +70,7 @@ Preconditions:
         duration_seconds: 300
         opModImpLimW: $(maxImportW * 2)
   instructions:
+    - DER shall be generating at the connection point at least 50% of its active power rating.
     - The test cannot be started until site telemetry is between 50 and 100% import (check the sign carefully).
     - Device telemetry must also be sent, and is the inverse of site (check the sign carefully).
 Steps:

--- a/cactus_test_definitions/client/procedures/LOA-01.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-01.yaml
@@ -12,6 +12,19 @@ Criteria:
   checks:
     - type: all-steps-complete
       parameters: {}
+    - type: readings-site-active-power
+      # site active power should never exceed its own rated import capacity
+      # site active power should always be positive during this test: with import at 50% for test start,
+      # we assume load must be sufficient to offset any on site generation and keep site power above 0.
+      # there is also a default control with opmodexplimw=0.
+      parameters:
+        minimum_level: $(1.05 * maxImportW)
+        maximum_level: $(-0.05 * maxImportW)
+    - type: readings-der-active-power
+      # DER is assumed to act as the inverse of the site power above. 
+      parameters:
+        maximum_level: $(-1.05 * maxImportW)
+        minimum_level: $(0.05 * maxImportW)
 
 Preconditions:
   init_actions:
@@ -36,6 +49,20 @@ Preconditions:
       parameters: {}
     - type: der-settings-contents
       parameters: {}
+    - type: readings-site-active-power
+      # Gate test start on telemetry rather than trusting the out-of-band instruction below alone: confirm the
+      # site is currently importing between 50% and 105% of the DER's rated import capacity.
+      parameters:
+        latest_reading_only: true
+        minimum_level: $(1.05 * maxImportW)
+        maximum_level: $(0.5 * maxImportW)
+    - type: readings-der-active-power
+      # Gate test start on telemetry rather than trusting the out-of-band instruction below alone: confirm the
+      # device is currently importing between 50% and 105% of the DER's rated import capacity.
+      parameters:
+        latest_reading_only: true
+        maximum_level: $(-1.05 * maxImportW)
+        minimum_level: $(-0.5 * maxImportW)
   actions:
     - type: create-der-control
       parameters:

--- a/cactus_test_definitions/client/procedures/LOA-01.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-01.yaml
@@ -70,7 +70,7 @@ Preconditions:
         duration_seconds: 300
         opModImpLimW: $(maxImportW * 2)
   instructions:
-    - DER shall be generating at the connection point at least 50% of its active power rating.
+    - DER shall be importing at the connection point at least 50% of its active power rating.
     - The test cannot be started until site telemetry is between 50 and 100% import (check the sign carefully).
     - Device telemetry must also be sent, and is the inverse of site (check the sign carefully).
 Steps:

--- a/cactus_test_definitions/variable_expressions.py
+++ b/cactus_test_definitions/variable_expressions.py
@@ -88,7 +88,6 @@ class NamedVariableType(IntEnum):
 
     # Storage extension
     DERSETTING_SET_MIN_WH = auto()
-    DERCAPABILITY_NEG_RTG_MAX_CHARGE_RATE_W = auto()  # -W (after multiplier applied), reference $negRtgMaxChargeRateW
 
     # Synthetic directional power limits - account for devices with asymmetric import/export capability.
     # MUST resolve to the relevant directional DERSetting rate when the device declares it, otherwise fall back to
@@ -150,8 +149,6 @@ def named_variable_repr(named_var: NamedVariableType) -> str:  # noqa: C901
     if len(name.split("_")) == 1:
         return snake_to_camel(name)
     match name.split("_", 1):
-        case ["DERCAPABILITY", "NEG_RTG_MAX_CHARGE_RATE_W"]:
-            return "(-DERCapability.rtgMaxChargeRateW)"
         case ["DERCAPABILITY", "RTG_MAX_VA"]:
             return "DERCapability.rtgMaxVA"
         case ["DERCAPABILITY", "RTG_MIN_PF_OVER_EXCITED"]:
@@ -242,6 +239,19 @@ class Expression(BaseExpression):
                 f"{self.rhs_operand.expression_representation()}",
             ]
         )
+
+
+@dataclass
+class Negate(BaseExpression):
+    """Unary negation of a single already-parsed sub-expression (eg '-maxExportW', '-(1.05 * maxExportW)').
+
+    The operand must be a single NamedVariable, Constant, or one-level Expression - this doesn't support
+    arbitrary nesting depth (eg negating a Negate isn't supported)."""
+
+    operand: NamedVariable | Constant | Expression
+
+    def expression_representation(self) -> str:
+        return f"-({self.operand.expression_representation()})"
 
 
 def parse_time_delta(var_body: str) -> timedelta:
@@ -342,8 +352,6 @@ def parse_unary_expression(token: Token) -> Constant | NamedVariable:  # noqa: C
             # Storage extension
             case "setMinWh":
                 return NamedVariable(NamedVariableType.DERSETTING_SET_MIN_WH)
-            case "negRtgMaxChargeRateW":
-                return NamedVariable(NamedVariableType.DERCAPABILITY_NEG_RTG_MAX_CHARGE_RATE_W)
             case "valid_nmi_1":
                 return NamedVariable(NamedVariableType.NMI_1)
             case "valid_nmi_2":
@@ -387,7 +395,9 @@ def parse_binary_expression(lhs_token: Token, operation: Token, rhs_token: Token
     return Expression(operation=operation_type, lhs_operand=lhs, rhs_operand=rhs)
 
 
-def parse_variable_expression_body(var_body: str, param_key: str | None) -> NamedVariable | Expression | Constant:
+def parse_variable_expression_body(
+    var_body: str, param_key: str | None
+) -> NamedVariable | Expression | Constant | Negate:
     """Given a variable definition: $(now - '5 seconds') - this function should be passed contents of that variable
     definition (the string within the parentheses) eg: "now - '5 seconds'
 
@@ -419,6 +429,20 @@ def parse_variable_expression_body(var_body: str, param_key: str | None) -> Name
         ]
     except tokenize.TokenError as err:
         raise UnparseableVariableExpressionError(f"Error tokenizing '{var_body}'") from err
+
+    # A leading '-' negates the (unary or binary) expression that follows it - eg '-maxExportW' or
+    # '-1.05 * maxExportW'. A '-' anywhere else (eg '0 - maxExportW') is binary subtraction, handled below as
+    # before.
+    if var_tokens and var_tokens[0].type == tokenize.OP and var_tokens[0].string == "-":
+        remainder = var_tokens[1:]
+        if len(remainder) == 1:
+            return Negate(parse_unary_expression(remainder[0]))
+        elif len(remainder) == 3:
+            return Negate(parse_binary_expression(remainder[0], remainder[1], remainder[2]))
+        else:
+            raise UnparseableVariableExpressionError(
+                f"Unable to parse {var_body} into a simple negated binary/unary expression"
+            )
 
     if len(var_tokens) == 1:
         return parse_unary_expression(var_tokens[0])
@@ -485,7 +509,7 @@ def try_extract_variable_expression(body: Any) -> str | None:  # noqa: ANN401
 
 def is_resolvable_variable(v: Any) -> bool:  # noqa: ANN401
     """Returns True if the supplied value is a variable definition that requires resolving"""
-    return isinstance(v, NamedVariable) or isinstance(v, Expression) or isinstance(v, Constant)
+    return isinstance(v, NamedVariable) or isinstance(v, Expression) or isinstance(v, Constant) or isinstance(v, Negate)
 
 
 def has_named_variable(

--- a/tests/unit/test_variable_expressions.py
+++ b/tests/unit/test_variable_expressions.py
@@ -11,6 +11,7 @@ from cactus_test_definitions.variable_expressions import (
     Expression,
     NamedVariable,
     NamedVariableType,
+    Negate,
     OperationType,
     UnparseableVariableExpressionError,
     has_named_variable,
@@ -249,23 +250,38 @@ def test_parse_time_delta(unquoted_raw: str, expected: timedelta | type[Exceptio
             "setMinWh >= 0.5",
             Expression(OperationType.GTE, NamedVariable(NamedVariableType.DERSETTING_SET_MIN_WH), Constant(0.5)),
         ),
-        (
-            "negRtgMaxChargeRateW + 50",
-            Expression(
-                OperationType.ADD,
-                NamedVariable(NamedVariableType.DERCAPABILITY_NEG_RTG_MAX_CHARGE_RATE_W),
-                Constant(50),
-            ),
-        ),
         ("randuri_1", NamedVariable(NamedVariableType.RANDURI_1)),
         ("randuri_2", NamedVariable(NamedVariableType.RANDURI_2)),
         ("randuri_3", NamedVariable(NamedVariableType.RANDURI_3)),
         ("randuri_", UnparseableVariableExpressionError),
         ("randuri", UnparseableVariableExpressionError),
+        # Unary negation - a leading '-' negates the (unary or binary) expression that follows it
+        ("-maxExportW", Negate(NamedVariable(NamedVariableType.DERSETTING_MAX_EXPORT_W))),
+        ("-rtgMaxChargeRateW", Negate(NamedVariable(NamedVariableType.DERCAPABILITY_RTG_MAX_CHARGE_RATE_W))),
+        (
+            "-1.05 * maxExportW",
+            Negate(
+                Expression(OperationType.MULTIPLY, Constant(1.05), NamedVariable(NamedVariableType.DERSETTING_MAX_EXPORT_W))  # noqa: E501
+            ),
+        ),
+        (
+            "-maxExportW * 1.05",
+            Negate(
+                Expression(OperationType.MULTIPLY, NamedVariable(NamedVariableType.DERSETTING_MAX_EXPORT_W), Constant(1.05))  # noqa: E501
+            ),
+        ),
+        # A '-' that isn't the leading token is still binary subtraction, not negation
+        ("5 - 3", Expression(OperationType.SUBTRACT, Constant(5), Constant(3))),
+        (
+            "now - '5 minutes'",
+            Expression(OperationType.SUBTRACT, NamedVariable(NamedVariableType.NOW), Constant(timedelta(minutes=5))),
+        ),
+        ("-", UnparseableVariableExpressionError),  # Nothing to negate
+        ("--maxExportW", UnparseableVariableExpressionError),  # Double negation/nesting isn't supported
     ],
 )
 def test_parse_variable_expression_body(
-    var_body: str, expected: type[Exception] | NamedVariable | Constant | Expression
+    var_body: str, expected: type[Exception] | NamedVariable | Constant | Expression | Negate
 ):
     """Top level parsing test to ensure that a variety of variable bodies parse (or fail) in an expected fashion"""
 
@@ -274,7 +290,7 @@ def test_parse_variable_expression_body(
             parse_variable_expression_body(var_body, None)
     else:
         actual = parse_variable_expression_body(var_body, None)
-        assert isinstance(actual, NamedVariable) or isinstance(actual, Constant) or isinstance(actual, Expression)
+        assert isinstance(actual, NamedVariable | Constant | Expression | Negate)
         assert actual == expected, f"Input string: {var_body}"
 
 
@@ -329,6 +345,7 @@ def test_parse_variable_expression_body_this(
         (Constant(1.23), True),
         (Constant(timedelta(5)), True),
         (Expression(OperationType.ADD, Constant(1.23), NamedVariable(NamedVariableType.NOW)), True),
+        (Negate(NamedVariable(NamedVariableType.NOW)), True),
     ],
 )
 def test_is_resolvable_variable(input: Any, expected: bool):
@@ -398,7 +415,6 @@ def test_snake_to_camel(input: str, expected: str) -> None:
         (NamedVariableType.DERSETTING_SET_MIN_PF_UNDER_EXCITED, "DERSetting.setMinPFUnderExcited"),
         (NamedVariableType.DERCAPABILITY_RTG_MIN_PF_OVER_EXCITED, "DERCapability.rtgMinPFOverExcited"),
         (NamedVariableType.DERCAPABILITY_RTG_MIN_PF_UNDER_EXCITED, "DERCapability.rtgMinPFUnderExcited"),
-        (NamedVariableType.DERCAPABILITY_NEG_RTG_MAX_CHARGE_RATE_W, "(-DERCapability.rtgMaxChargeRateW)"),
         (NamedVariableType.DERSETTING_MAX_IMPORT_W, "(DERSetting.setMaxChargeRateW or DERSetting.setMaxW)"),
         (NamedVariableType.DERSETTING_MAX_EXPORT_W, "(DERSetting.setMaxDischargeRateW or DERSetting.setMaxW)"),
         (NamedVariableType.NOW, "now"),
@@ -436,6 +452,10 @@ def test_operation_repr(input: OperationType, expected: str) -> None:
             "DERSetting.setMinWh + 5.5",
         ),
         (Constant(654.456), "654.456"),
+        (
+            Negate(NamedVariable(NamedVariableType.DERSETTING_MAX_EXPORT_W)),
+            "-((DERSetting.setMaxDischargeRateW or DERSetting.setMaxW))",
+        ),
     ],
 )
 def test_base_expression_expression_representation(input: BaseExpression, expected: str) -> None:

--- a/tests/unit/test_variable_expressions.py
+++ b/tests/unit/test_variable_expressions.py
@@ -261,13 +261,17 @@ def test_parse_time_delta(unquoted_raw: str, expected: timedelta | type[Exceptio
         (
             "-1.05 * maxExportW",
             Negate(
-                Expression(OperationType.MULTIPLY, Constant(1.05), NamedVariable(NamedVariableType.DERSETTING_MAX_EXPORT_W))  # noqa: E501
+                Expression(
+                    OperationType.MULTIPLY, Constant(1.05), NamedVariable(NamedVariableType.DERSETTING_MAX_EXPORT_W)
+                )  # noqa: E501
             ),
         ),
         (
             "-maxExportW * 1.05",
             Negate(
-                Expression(OperationType.MULTIPLY, NamedVariable(NamedVariableType.DERSETTING_MAX_EXPORT_W), Constant(1.05))  # noqa: E501
+                Expression(
+                    OperationType.MULTIPLY, NamedVariable(NamedVariableType.DERSETTING_MAX_EXPORT_W), Constant(1.05)
+                )  # noqa: E501
             ),
         ),
         # A '-' that isn't the leading token is still binary subtraction, not negation


### PR DESCRIPTION
NOTE: Will need to be caught in runner before deployment. 

Adds the Negate variable expression to simplify things (otherwise we would need at least 3 more like negSetMaxW etc). Hopefully a bit of future-proofing. 

Adds telemetry checks to GEN-01 and LOA-01:
1) Gate start on the latest telemetry reading being between 50 and 100%
2) Check all telemetry is of the correct sign throughout the whole test (site positive device negative for LOA-01 for example). 