### PR TITLE
add_better_defaults_ALL_26_and_27

### DIFF
--- a/cactus_test_definitions/client/procedures/ALL-26.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-26.yaml
@@ -34,8 +34,8 @@ Preconditions:
         primacy: 0
     - type: set-default-der-control
       parameters:
-        opModImpLimW: 0
-        opModExpLimW: 0
+        opModImpLimW: $(maxImportW) # Increased from 0 in TS5573 table 12.4.4 so that the reconnect can be easily observed
+        opModExpLimW: $(maxExportW) # Increased from 0 in TS5573 table 12.4.4 so that the reconnect can be easily observed
         setGradW: 27
   instructions:
     - DER shall be exporting or importing at least 50% of its active power rating at the connection point.

--- a/cactus_test_definitions/client/procedures/ALL-27.yaml
+++ b/cactus_test_definitions/client/procedures/ALL-27.yaml
@@ -34,8 +34,8 @@ Preconditions:
         primacy: 0
     - type: set-default-der-control
       parameters:
-        opModImpLimW: 0
-        opModExpLimW: 0
+        opModImpLimW: $(maxImportW) # Increased from 0 in TS5573 table 12.4.4 so that the reconnect can be easily observed
+        opModExpLimW: $(maxExportW) # Increased from 0 in TS5573 table 12.4.4 so that the reconnect can be easily observed
         setGradW: 27
     
 Steps:


### PR DESCRIPTION
If the default limits are 0, there is no way to witness test a reconnect or re-energise step. Set to 100% instead.