### PR TITLE
all_poll_check_GEN_LOA_02

### DIFF
--- a/cactus_test_definitions/client/procedures/GEN-02.yaml
+++ b/cactus_test_definitions/client/procedures/GEN-02.yaml
@@ -12,7 +12,18 @@ Criteria:
   checks:
     - type: all-steps-complete
       parameters: {}
-
+    - type: all-polls-at-correct-time
+      parameters:
+        endpoints:
+          - /dcap
+          - /edev
+          - /edev/1/fsa
+          - /edev/1/der
+          - /edev/1/fsa/1/derp
+          - /edev/1/derp/1/dderc
+          - /mup
+        poll_interval_seconds: 60
+        request_type_str: GET
 
 Preconditions:
   init_actions:

--- a/cactus_test_definitions/client/procedures/LOA-02.yaml
+++ b/cactus_test_definitions/client/procedures/LOA-02.yaml
@@ -12,6 +12,18 @@ Criteria:
   checks:
     - type: all-steps-complete
       parameters: {}
+    - type: all-polls-at-correct-time
+      parameters:
+        endpoints:
+          - /dcap
+          - /edev
+          - /edev/1/fsa
+          - /edev/1/der
+          - /edev/1/fsa/1/derp
+          - /edev/1/derp/1/dderc
+          - /mup
+        poll_interval_seconds: 60
+        request_type_str: GET
 
 Preconditions:
   init_actions:


### PR DESCRIPTION
No specific reason for these other than simple tests for minimum client disturbance.

Additional telemetry checks are being added to GEN and LOA-01 making these logical places to add more poll checks. Test is about 3 mins so this mostly checks against over-polling.